### PR TITLE
Fixed generated code directory to reflect new namespace

### DIFF
--- a/azure-iot-provisioning-servicesdk/protocol-generator.md
+++ b/azure-iot-provisioning-servicesdk/protocol-generator.md
@@ -20,5 +20,5 @@ input-file: service.json
 
 python:
     namespace: protocol
-    output-folder: azure/iot/sdk/provisioning/service
+    output-folder: azure/iot/provisioning/servicesdk
 ```


### PR DESCRIPTION
DPS code was being generated in the wrong directory since I hadn't updated the generation script to account for the new namespacing. 