### PR TITLE
feat(device): add x509 authentication

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -114,3 +114,6 @@ coverage/
 
 # Pycharm
 .idea/
+
+# Certificates
+*.pem

--- a/azure-iot-hub-devicesdk/azure/iot/hub/devicesdk/auth/authentication_provider_factory.py
+++ b/azure-iot-hub-devicesdk/azure/iot/hub/devicesdk/auth/authentication_provider_factory.py
@@ -6,6 +6,7 @@
 from .sk_authentication_provider import SymmetricKeyAuthenticationProvider
 from .sas_authentication_provider import SharedAccessSignatureAuthenticationProvider
 from .iotedge_authentication_provider import IotEdgeAuthenticationProvider
+from .x509_authentication_provider import X509AuthenticationProvider
 
 
 def from_connection_string(connection_string):
@@ -37,3 +38,16 @@ def from_environment():
     :return: iotedge AuthenticationProvider
     """
     return IotEdgeAuthenticationProvider()
+
+
+def from_x509(device_id, hostname, cert_file, key_file, passphrase=None):
+    """
+    Provides an `AuthenticationProvider` object that can be used to authenticate a device with an x509 Certificate/Key pair.
+
+    :param cert_string: The PEM string of the certificate
+    :param key_string: The PEM string of the key associated with the certificate
+    :param passphrase: The passphrase used to encrypt the key file
+
+    :return: X509 AuthenticationProvider
+    """
+    return X509AuthenticationProvider(device_id, hostname, cert_file, key_file, passphrase)

--- a/azure-iot-hub-devicesdk/azure/iot/hub/devicesdk/auth/x509_authentication_provider.py
+++ b/azure-iot-hub-devicesdk/azure/iot/hub/devicesdk/auth/x509_authentication_provider.py
@@ -1,0 +1,53 @@
+# --------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for license information.
+# --------------------------------------------------------------------------------------------
+from .authentication_provider import AuthenticationProvider
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+class X509Credentials:
+    """
+    A class with references to the certificate, key, and optional passphrase used to authenticate
+    a TLS connection using x509 certificates
+    """
+
+    def __init__(self, cert_file, key_file, passphrase=None):
+        self.cert_file = cert_file
+        self.key_file = key_file
+        self.passphrase = passphrase
+
+
+class X509AuthenticationProvider:
+    """
+    An X509 Authentication Provider. This provider uses the certificate and key
+    provided to authenticate a device with an Azure IoT Hub instance.
+
+    X509 Authentication is only supported for device identities connecting directly to an Azure IoT hub.
+    """
+
+    def __init__(self, device_id, hostname, cert_file, key_file, passphrase=None):
+        """
+        Constructor for the X509AuthenticationProvider class.
+
+        :param device_id: The device unique identifier as it exists in the Azure IoT Hub device registry
+        :param hostname: The hostname of the Azure IoT hub.
+        :param cert_file: The path to the pem file containing the certificate (or certificate chain) used to authenticate the device
+        :param key_file: The path to the pem file containing the key associated with the certificate
+        :param passhphrase: (optional) The passphrase used to encode the key file
+        """
+
+        logger.info("Using X509 authentication for {%s, %s}", hostname, device_id)
+        self.hostname = hostname
+        self.device_id = device_id
+        self.module_id = None  # Modules do not support X509 Authentication (for now)
+        self.x509 = X509Credentials(cert_file, key_file, passphrase)
+
+    def disconnect(self):
+        """
+        Closes any timers or resources used by the authentication provider.
+        This is called when the transport is disconnected.
+        """
+        return

--- a/azure-iot-hub-devicesdk/samples/authentication_providers.py
+++ b/azure-iot-hub-devicesdk/samples/authentication_providers.py
@@ -9,6 +9,7 @@ from azure.iot.hub.devicesdk.auth.authentication_provider_factory import (
     from_shared_access_signature,
     from_connection_string,
     from_environment,
+    from_x509,
 )
 
 # To understand authentication providers, it is beneficial to be familiar with the Azure IoT Hub Security model:
@@ -26,6 +27,15 @@ key_auth_provider = from_connection_string("IOTHUB_DEVICE_CONNECTION_STRING")
 
 # - Pre-defined environment variables (this is especially useful when running as an Azure IoT Edge module)
 env_auth_provider = from_environment()
+
+# - X509 Certificate Authentication Provider'
+cert_file = "../scripts/certificate.pem"
+key_file = "../scripts/key.pem"
+passphrase = "passphrase"
+
+x509_auth_provider = from_x509(
+    os.getenv("DEVICE_ID"), os.getenv("HOSTNAME"), cert_file, key_file, passphrase
+)
 
 # Once the authentication provider has been created, it can be passed to the client:
 device_client = DeviceClient.from_authentication_provider(key_auth_provider, "mqtt")

--- a/azure-iot-hub-devicesdk/samples/x509_send_telemetry.py
+++ b/azure-iot-hub-devicesdk/samples/x509_send_telemetry.py
@@ -1,0 +1,48 @@
+# --------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for license information.
+# --------------------------------------------------------------------------------------------
+import os
+import time
+from azure.iot.hub.devicesdk.device_client import DeviceClient
+from azure.iot.hub.devicesdk.auth.authentication_provider_factory import from_x509
+
+
+# X509 certificate and key paths, and optional passphrase
+# The certificate and key files can be created using OpenSSL for example.
+# For convenience (not production), the repository contains a script that
+# helps generate these files:
+# scripts/gen_self_signed_cert_not_for_production.py
+cert_file = "../../scripts/certificate.pem"
+key_file = "../../scripts/key.pem"
+passphrase = "passphrase"
+
+# The "Authentication Provider" will hold references to the device identity and certificate information and provide them to the transport when necessary
+x509_auth_provider = from_x509(
+    os.getenv("IOTHUB_DEVICE_ID"), os.getenv("IOTHUB_HOSTNAME"), cert_file, key_file, passphrase
+)
+
+# For now, the SDK only supports MQTT as a protocol. the client object is used to interact with your Azure IoT hub.
+# It needs an Authentication Provider to secure the communication with the hub, using either tokens or x509 certificates
+device_client = DeviceClient.from_authentication_provider(x509_auth_provider, "mqtt")
+
+
+# The connection state callback allows us to detect when the client is connected and disconnected:
+def connection_state_callback(status):
+    print("connection status: " + status)
+
+
+# Register the connection state callback with the client...
+device_client.on_connection_state = connection_state_callback
+
+# ... and connect the client.
+device_client.connect()
+
+# send 5 messages with a 1 second pause between each message
+for i in range(0, 5):
+    print("sending message #" + str(i))
+    device_client.send_event("test_payload message " + str(i))
+    time.sleep(1)
+
+# finally, disconnect
+device_client.disconnect()

--- a/azure-iot-hub-devicesdk/tests/test_authentication_provider_factory.py
+++ b/azure-iot-hub-devicesdk/tests/test_authentication_provider_factory.py
@@ -6,6 +6,7 @@
 from azure.iot.hub.devicesdk.auth.authentication_provider_factory import (
     from_connection_string,
     from_shared_access_signature,
+    from_x509,
 )
 from azure.iot.hub.devicesdk.auth.sk_authentication_provider import (
     SymmetricKeyAuthenticationProvider,
@@ -13,7 +14,10 @@ from azure.iot.hub.devicesdk.auth.sk_authentication_provider import (
 from azure.iot.hub.devicesdk.auth.sas_authentication_provider import (
     SharedAccessSignatureAuthenticationProvider,
 )
-
+from azure.iot.hub.devicesdk.auth.x509_authentication_provider import (
+    X509Credentials,
+    X509AuthenticationProvider,
+)
 
 connection_string_device_sk_format = "HostName={};DeviceId={};SharedAccessKey={}"
 connection_string_device_skn_format = (
@@ -34,6 +38,9 @@ module_id = "Divination"
 gateway_name = "EnchantedCeiling"
 signature = "IsolemnlySwearThatIamuUptoNogood"
 expiry = "1539043658"
+cert_file_path = "/cert/path"
+key_file_path = "/key/path"
+passphrase = "passphrase"
 
 
 sas_device_token_format = "SharedAccessSignature sr={}&sig={}&se={}"
@@ -99,3 +106,25 @@ def create_sas_token_string(is_module=False, is_key_name=False):
         return sas_device_skn_token_format.format(uri, signature, expiry, shared_access_key_name)
     else:
         return sas_device_token_format.format(uri, signature, expiry)
+
+
+def test_x509_auth_provider_created_correctly_without_passphrase():
+    auth_provider = from_x509(device_id, hostname, cert_file_path, key_file_path)
+    assert isinstance(auth_provider, X509AuthenticationProvider)
+    assert auth_provider.device_id == device_id
+    assert auth_provider.hostname == hostname
+    assert isinstance(auth_provider.x509, X509Credentials)
+    assert auth_provider.x509.cert_file == cert_file_path
+    assert auth_provider.x509.key_file == key_file_path
+    assert auth_provider.x509.passphrase is None
+
+
+def test_x509_auth_provider_created_correctly_with_passphrase():
+    auth_provider = from_x509(device_id, hostname, cert_file_path, key_file_path, passphrase)
+    assert isinstance(auth_provider, X509AuthenticationProvider)
+    assert auth_provider.device_id == device_id
+    assert auth_provider.hostname == hostname
+    assert isinstance(auth_provider.x509, X509Credentials)
+    assert auth_provider.x509.cert_file == cert_file_path
+    assert auth_provider.x509.key_file == key_file_path
+    assert auth_provider.x509.passphrase == passphrase

--- a/azure-iot-hub-devicesdk/tests/test_base_renewable_token_authentication_provider.py
+++ b/azure-iot-hub-devicesdk/tests/test_base_renewable_token_authentication_provider.py
@@ -150,9 +150,7 @@ def test_generate_new_sas_token_cancels_and_reschedules_update_timer_with_correc
     device_auth_provider.token_validity_period = new_token_validity_period
     device_auth_provider.token_renewal_margin = new_token_renewal_margin
     device_auth_provider.generate_new_sas_token()
-    assert (
-        fake_timer_object.call_args[0][0] == new_token_validity_period - new_token_renewal_margin
-    )
+    assert fake_timer_object.call_args[0][0] == new_token_validity_period - new_token_renewal_margin
 
 
 def test_update_timer_generates_new_sas_token_and_calls_token_update_callback(

--- a/azure-iot-hub-devicesdk/tests/test_mqtt_provider.py
+++ b/azure-iot-hub-devicesdk/tests/test_mqtt_provider.py
@@ -4,6 +4,7 @@
 # --------------------------------------------------------------------------------------------
 
 from azure.iot.hub.devicesdk.transport.mqtt.mqtt_provider import MQTTProvider
+from azure.iot.hub.devicesdk.auth.x509_authentication_provider import X509Credentials
 import paho.mqtt.client as mqtt
 import ssl
 import pytest
@@ -14,6 +15,10 @@ fake_device_id = "MyFirebolt"
 fake_password = "Fortuna Major"
 fake_username = fake_hostname + "/" + fake_device_id
 new_fake_password = "new fake password"
+fake_cert_file = "cert_file"
+fake_key_file = "key_file"
+fake_passphrase = "passphrase"
+fake_x509 = X509Credentials(fake_cert_file, fake_key_file, fake_passphrase)
 
 
 @patch.object(ssl, "SSLContext")
@@ -37,6 +42,37 @@ def test_connect_triggers_client_connect(MockMqttClient, MockSsl):
         username=fake_username, password=fake_password
     )
     mock_mqtt_client.connect.assert_called_once_with(host=fake_hostname, port=8883)
+    mock_mqtt_client.username_pw_set.assert_called_once_with(
+        username=fake_username, password=fake_password
+    )
+    mock_mqtt_client.loop_start.assert_called_once_with()
+
+    assert mock_mqtt_client.on_connect is not None
+    assert mock_mqtt_client.on_disconnect is not None
+    assert mock_mqtt_client.on_publish is not None
+    assert mock_mqtt_client.on_subscribe is not None
+
+
+@patch.object(ssl, "SSLContext")
+@patch.object(mqtt, "Client")
+def test_connect_triggers_client_connect_with_x509(MockMqttClient, MockSsl):
+    mqtt_provider = MQTTProvider(fake_device_id, fake_hostname, fake_username)
+    mqtt_provider.connect(None, fake_x509)
+
+    MockMqttClient.assert_called_once_with(fake_device_id, False, protocol=4)
+    mock_mqtt_client = MockMqttClient.return_value
+
+    MockSsl.assert_called_once_with(ssl.PROTOCOL_TLSv1_2)
+
+    assert mock_mqtt_client.tls_set_context.call_count == 1
+    context = mock_mqtt_client.tls_set_context.call_args[0][0]
+    assert context.check_hostname is True
+    assert context.verify_mode == ssl.CERT_REQUIRED
+    context.load_default_certs.assert_called_once_with()
+    context.load_cert_chain.assert_called_once_with(fake_cert_file, fake_key_file, fake_passphrase)
+    mock_mqtt_client.tls_insecure_set.assert_called_once_with(False)
+    mock_mqtt_client.connect.assert_called_once_with(host=fake_hostname, port=8883)
+    mock_mqtt_client.username_pw_set.assert_called_once_with(username=fake_username, password=None)
     mock_mqtt_client.loop_start.assert_called_once_with()
 
     assert mock_mqtt_client.on_connect is not None

--- a/azure-iot-hub-devicesdk/tests/test_mqtt_transport.py
+++ b/azure-iot-hub-devicesdk/tests/test_mqtt_transport.py
@@ -196,7 +196,7 @@ class TestSendEvent:
         transport.send_event(fake_msg)
 
         mock_mqtt_provider.connect.assert_called_once_with(
-            transport._auth_provider.get_current_sas_token()
+            transport._auth_provider.get_current_sas_token(), None
         )
         mock_mqtt_provider.publish.assert_called_once_with(fake_topic, fake_msg.data)
 
@@ -228,7 +228,7 @@ class TestSendEvent:
         transport_module.send_event(fake_msg)
 
         mock_mqtt_provider.connect.assert_called_once_with(
-            transport_module._auth_provider.get_current_sas_token()
+            transport_module._auth_provider.get_current_sas_token(), None
         )
         mock_mqtt_provider.publish.assert_called_once_with(fake_output_topic, fake_msg.data)
 

--- a/azure-iot-hub-devicesdk/tests/test_x509_authentication_provider.py
+++ b/azure-iot-hub-devicesdk/tests/test_x509_authentication_provider.py
@@ -1,0 +1,46 @@
+# --------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for license information.
+# --------------------------------------------------------------------------------------------
+import pytest
+from azure.iot.hub.devicesdk.auth.x509_authentication_provider import (
+    X509Credentials,
+    X509AuthenticationProvider,
+)
+
+
+def test_x509_auth_provider_constructor_populates_properties_correctly_without_passphrase():
+    test_device_id = "device_id"
+    test_hostname = "host.name"
+    test_cert_file_path = "/cert/path"
+    test_key_file_path = "/key/path"
+
+    auth_provider = X509AuthenticationProvider(
+        test_device_id, test_hostname, test_cert_file_path, test_key_file_path
+    )
+    assert isinstance(auth_provider, X509AuthenticationProvider)
+    assert auth_provider.device_id == test_device_id
+    assert auth_provider.hostname == test_hostname
+    assert isinstance(auth_provider.x509, X509Credentials)
+    assert auth_provider.x509.cert_file == test_cert_file_path
+    assert auth_provider.x509.key_file == test_key_file_path
+    assert auth_provider.x509.passphrase is None
+
+
+def test_x509_auth_provider_constructor_populates_properties_correctly_with_passphrase():
+    test_device_id = "device_id"
+    test_hostname = "host.name"
+    test_cert_file_path = "/cert/path"
+    test_key_file_path = "/key/path"
+    test_passphrase = "passphrase"
+
+    auth_provider = X509AuthenticationProvider(
+        test_device_id, test_hostname, test_cert_file_path, test_key_file_path, test_passphrase
+    )
+    assert isinstance(auth_provider, X509AuthenticationProvider)
+    assert auth_provider.device_id == test_device_id
+    assert auth_provider.hostname == test_hostname
+    assert isinstance(auth_provider.x509, X509Credentials)
+    assert auth_provider.x509.cert_file == test_cert_file_path
+    assert auth_provider.x509.key_file == test_key_file_path
+    assert auth_provider.x509.passphrase == test_passphrase

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ six
 mock
 black; python_version >= '3.6'
 pre-commit
+cryptography

--- a/scripts/gen_self_signed_cert_not_for_production.py
+++ b/scripts/gen_self_signed_cert_not_for_production.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python
+from cryptography import x509
+from cryptography.x509.oid import NameOID
+from cryptography.hazmat.backends import default_backend
+from cryptography.hazmat.primitives import serialization, hashes
+from cryptography.hazmat.primitives.asymmetric import rsa
+
+from datetime import datetime, timedelta
+
+cert_file_name = "./certificate.pem"
+key_file_name = "./key.pem"
+passphrase = b"passphrase"
+
+# Generate our key
+key = rsa.generate_private_key(public_exponent=65537, key_size=2048, backend=default_backend())
+# Write our key to disk for safe keeping
+with open("./key.pem", "wb") as f:
+    f.write(
+        key.private_bytes(
+            encoding=serialization.Encoding.PEM,
+            format=serialization.PrivateFormat.TraditionalOpenSSL,
+            encryption_algorithm=serialization.BestAvailableEncryption(passphrase),
+        )
+    )
+# Various details about who we are. For a self-signed certificate the
+# subject and issuer are always the same.
+subject = issuer = x509.Name(
+    [
+        x509.NameAttribute(NameOID.COUNTRY_NAME, u"US"),
+        x509.NameAttribute(NameOID.STATE_OR_PROVINCE_NAME, u"WA"),
+        x509.NameAttribute(NameOID.LOCALITY_NAME, u"Redmond"),
+        x509.NameAttribute(NameOID.ORGANIZATION_NAME, u"ContosoDoNotUse"),
+        x509.NameAttribute(NameOID.COMMON_NAME, u"self-signed-do-not-use"),
+    ]
+)
+cert = (
+    x509.CertificateBuilder()
+    .subject_name(subject)
+    .issuer_name(issuer)
+    .public_key(key.public_key())
+    .serial_number(x509.random_serial_number())
+    .not_valid_before(datetime.utcnow())
+    .not_valid_after(
+        # Our certificate will be valid for 10 days
+        datetime.utcnow()
+        + timedelta(days=10)
+    )
+    .add_extension(
+        x509.SubjectAlternativeName([x509.DNSName(u"localhost")]),
+        critical=False,
+        # Sign our certificate with our private key
+    )
+    .sign(key, hashes.SHA256(), default_backend())
+)
+
+thumbprint = cert.fingerprint(hashes.SHA1()).hex()
+
+# Write our certificate out to disk.
+with open(cert_file_name, "wb") as f:
+    f.write(cert.public_bytes(serialization.Encoding.PEM))
+
+print("Certificate:", cert_file_name)
+print("Key:", key_file_name)
+print("Thumbprint:", thumbprint)


### PR DESCRIPTION
First stab at adding X509 authentication for devices.

Please start the review with the sample called `x509_send_telemetry.py`

Things I need help with:
- decide whether from_connection_string should support X509 connection strings
  - if Yes: how do we pass the cert/key later? other SDKs do set_options, everybody hates that.
  - if No: well, it's still a valid connection string... so not ideal
- The structure of the x509 properties inside the x509 authentication provider. Not sure why we'd need to encapsulate cert_file and key_file in the X509Credentials class but I liked having everything under the same structure. not sure why. maybe because of some node SDK influence
- I have not tested with properly signed device certs, as well as cert chains. those should behave the same though, code would not change.
- The tests for the AuthenticationProvider constructor and AuthenticationProvider factories are exactly the same - not sure I enjoy the duplication

Other things to note:
- I added a couple of unrelated tests, it's not a mistake/left-over
- I had to add a `__init__.py` file in the test folder for VS Code to properly detect tests and show the Run/Debug buttons in the code-lens. Anyone made it work without it?

Have tested only on python 3.7 so far.