### PR TITLE
disable/unsubscribe with tests

### DIFF
--- a/azure-iot-hub-devicesdk/tests/transport/mqtt/test_mqtt_provider.py
+++ b/azure-iot-hub-devicesdk/tests/transport/mqtt/test_mqtt_provider.py
@@ -150,3 +150,15 @@ def test_subscribe_calls_subscribe_on_mqtt_client(MockMqttClient):
 
     assert sub_mid == fake_mid
     mock_mqtt_client.subscribe.assert_called_once_with(fake_topic, fake_qos)
+
+
+@patch.object(mqtt, "Client")
+def test_unsubscribe_calls_unsubscribe_on_mqtt_client(MockMqttClient):
+    mock_mqtt_client = MockMqttClient.return_value
+    mock_mqtt_client.unsubscribe = MagicMock(return_value=(fake_rc, fake_mid))
+
+    mqtt_provider = MQTTProvider(fake_device_id, fake_hostname, fake_username)
+    unsub_mid = mqtt_provider.unsubscribe(fake_topic)
+
+    assert unsub_mid == fake_mid
+    mock_mqtt_client.unsubscribe.assert_called_once_with(fake_topic)

--- a/azure-iot-hub-devicesdk/tests/transport/mqtt/test_mqtt_transport.py
+++ b/azure-iot-hub-devicesdk/tests/transport/mqtt/test_mqtt_transport.py
@@ -413,3 +413,44 @@ class TestEnableC2D:
 
         # assert
         callback.assert_called_once_with()
+
+
+class TestDisableC2D:
+    def test_unsubscribe_calls_unsubscribe_on_provider(self, transport):
+        transport._c2d_topic = subscribe_c2d_topic
+        mock_mqtt_provider = transport._mqtt_provider
+
+        transport.connect()
+        mock_mqtt_provider.on_mqtt_connected()
+        transport.disable_c2d_messages()
+
+        mock_mqtt_provider.unsubscribe.assert_called_once_with(subscribe_c2d_topic)
+
+    def test_unsubscribe_of_input_calls_unsubscribe_on_provider(self, transport):
+        transport._input_topic = subscribe_input_message_topic
+        mock_mqtt_provider = transport._mqtt_provider
+
+        transport.connect()
+        mock_mqtt_provider.on_mqtt_connected()
+        transport.disable_input_messages()
+
+        mock_mqtt_provider.unsubscribe.assert_called_once_with(subscribe_input_message_topic)
+
+    def test_unsuback_of_c2d_calls_client_callback(self, transport):
+        transport._c2d_topic = subscribe_c2d_topic
+        mock_mqtt_provider = transport._mqtt_provider
+        mock_mqtt_provider.unsubscribe = MagicMock(return_value=56)
+
+        # connect
+        transport.connect()
+        mock_mqtt_provider.on_mqtt_connected()
+
+        # unsubscribe
+        callback = MagicMock()
+        transport.disable_c2d_messages(callback)
+
+        # fake the unsuback:
+        mock_mqtt_provider.on_mqtt_unsubscribed(56)
+
+        # assert
+        callback.assert_called_once_with()


### PR DESCRIPTION
Even though we disable the feature, and unsubscribe from mqtt , this does not stop the hub from sending messages. 
Still need to figure out how to do that.
Should we drop messages silently ?
Should we detach handler ?
Should we disconnect after disabling (not  a good option if the device still  wants telemetry)

We need to discuss regarding this options. So this is a basic disabling.
The sample to test does not exist in this branch. The sample and unused methods of client is in the branch `ok-disable-DONOT-DELETE`. 
