### PR TITLE
 Refactor state machine to prepare for methods

### DIFF
--- a/azure-iot-hub-devicesdk/azure/iot/hub/devicesdk/transport/constant.py
+++ b/azure-iot-hub-devicesdk/azure/iot/hub/devicesdk/transport/constant.py
@@ -6,5 +6,6 @@
 """This module contains constants realted to the transport package.
 """
 
+# Feature names
 C2D_MSG = "c2d"
 INPUT_MSG = "input"

--- a/azure-iot-hub-devicesdk/azure/iot/hub/devicesdk/transport/mqtt/mqtt_provider.py
+++ b/azure-iot-hub-devicesdk/azure/iot/hub/devicesdk/transport/mqtt/mqtt_provider.py
@@ -83,7 +83,7 @@ class MQTTProvider(object):
                 logger.error(traceback.format_exc())
 
         def on_message_callback(client, userdata, mqtt_message):
-            logger.info("message received")
+            logger.info("message received on %s", mqtt_message.topic)
             try:
                 self.on_mqtt_message_received(mqtt_message._topic, mqtt_message.payload)
             except:  # noqa: E722 do not use bare 'except'
@@ -166,7 +166,7 @@ class MQTTProvider(object):
         :return: message ID for the subscribe request
         Raises a ValueError if qos is not 0, 1 or 2, or if topic is None or has zero string length,
         """
-        logger.info("subscribing")
+        logger.info("subscribing to %s with qos %s", topic, str(qos))
         (result, mid) = self._mqtt_client.subscribe(topic, qos)
         return mid
 
@@ -177,6 +177,6 @@ class MQTTProvider(object):
         :return: mid the message ID for the unsubscribe request.
         Raises a ValueError if topic is None or has zero string length, or is not a string.
         """
-        logger.info("unsubscribing")
+        logger.info("unsubscribing from %s", topic)
         (result, mid) = self._mqtt_client.unsubscribe(topic)
         return mid

--- a/azure-iot-hub-devicesdk/azure/iot/hub/devicesdk/transport/mqtt/mqtt_provider.py
+++ b/azure-iot-hub-devicesdk/azure/iot/hub/devicesdk/transport/mqtt/mqtt_provider.py
@@ -36,6 +36,7 @@ class MQTTProvider(object):
         self.on_mqtt_published = None
         self.on_mqtt_subscribed = None
         self.on_mqtt_unsubscribed = None
+        self.on_mqtt_message_received = None
 
         self._create_mqtt_client()
 

--- a/azure-iot-hub-devicesdk/azure/iot/hub/devicesdk/transport/mqtt/mqtt_transport.py
+++ b/azure-iot-hub-devicesdk/azure/iot/hub/devicesdk/transport/mqtt/mqtt_transport.py
@@ -374,7 +374,7 @@ class MQTTTransport(AbstractTransport):
         self._mqtt_provider.on_mqtt_published = self._on_provider_publish_complete
         self._mqtt_provider.on_mqtt_subscribed = self._on_provider_subscribe_complete
         self._mqtt_provider.on_mqtt_unsubscribed = self._on_provider_unsubscribe_complete
-        self._mqtt_provider.on_mqtt_message = self._on_provider_message
+        self._mqtt_provider.on_mqtt_message_received = self._on_provider_message_received_callback
 
     def _get_telemetry_topic(self):
         topic = "devices/" + self._auth_provider.device_id

--- a/azure-iot-hub-devicesdk/tests/transport/mqtt/test_mqtt_provider.py
+++ b/azure-iot-hub-devicesdk/tests/transport/mqtt/test_mqtt_provider.py
@@ -82,6 +82,13 @@ def test_connect_triggers_client_connect(MockMqttClient, MockSsl):
             [1234],
             id="on_subscribe => on_mqtt_subscribed",
         ),
+        pytest.param(
+            "on_unsubscribe",
+            [None, None, 1235],
+            "on_mqtt_unsubscribed",
+            [1235],
+            id="on_unsubscribe => on_mqtt_unsubscribed",
+        ),
     ],
 )
 def test_mqtt_client_callback_triggers_provider_callback(

--- a/azure-iot-hub-devicesdk/tests/transport/mqtt/test_mqtt_transport.py
+++ b/azure-iot-hub-devicesdk/tests/transport/mqtt/test_mqtt_transport.py
@@ -399,8 +399,8 @@ class TestEnableInputMessage:
 
 
 class TestDisableInputMessage:
-    def test_unsubscribe_of_input_calls_unsubscribe_on_provider(self, transport):
-        transport._input_topic = subscribe_input_message_topic
+    def test_unsubscribe_of_input_calls_unsubscribe_on_provider(self, transport_module):
+        transport = transport_module
         mock_mqtt_provider = transport._mqtt_provider
 
         transport.connect()
@@ -410,7 +410,6 @@ class TestDisableInputMessage:
         mock_mqtt_provider.unsubscribe.assert_called_once_with(subscribe_input_message_topic)
 
     def test_unsuback_of_input_calls_client_callback(self, transport):
-        transport._input_topic = subscribe_input_message_topic
         mock_mqtt_provider = transport._mqtt_provider
         mock_mqtt_provider.unsubscribe = MagicMock(return_value=56)
 
@@ -429,7 +428,6 @@ class TestDisableInputMessage:
         callback.assert_called_once_with()
 
     def test_sets_input_message_status_to_disabled(self, transport):
-        transport._input_topic = subscribe_input_message_topic
         mock_mqtt_provider = transport._mqtt_provider
 
         transport.connect()


### PR DESCRIPTION
This builds on top of my previous PR. (https://github.com/Azure/azure-iot-sdk-python-preview/pull/62) 

To prepare for methods, I'm doing the following:
1. Make subscribe and unsubscribe into generic functions
2. Make those functions into "Actions" which can be queued up in the state machine once the machine is connected.  
3. Refactor the previous "send-event" code to execute on any queued actions.  This currently includes subscribe, unsubscribe, send-event.  I have a stubbed-out send-method-response action.

This is pushing the state machine into a place where there are 4 states (disconnected, connecting, connected, and disconnecting), and all operations turn into actions that go into a queue that gets processed at the appropriate time.  This is a departure from how we did it with the node sdk, but I think it can solve the same goals (for MQTT at least) with much more simplicity.  For the record, I think we'll have to add new states when we implement Twin (because we will need subscribe to be blocking), but that's a story for another time.  

This gives Carter a base to build the Method code on top of.  It still has the following weaknesses:
1. thread safety is not guaranteed.  See my previous PR-62
2. Subscribe and unsubscribe are actions just like "send event" and "send method response" and, as such, can be overlapped with any other actions.  This overlap is OK for now, but won't be forever.
3. Subscribe and unsubscribe actions go into the queue as lifo operations.  They probably need to go first, so we know that subscribes are complete before we do anything else.
4. There are transitions missing for some edge-cases (send-event while disconnecting, etc), and error handling needs to be shored up.  