### PR TITLE
Transport/Provider refactor

### DIFF
--- a/azure-iot-device/azure/iot/device/iothub/transport/mqtt/mqtt_provider.py
+++ b/azure-iot-device/azure/iot/device/iothub/transport/mqtt/mqtt_provider.py
@@ -14,16 +14,23 @@ logger = logging.getLogger(__name__)
 
 class MQTTProvider(object):
     """
-    A wrapper over the actual implementation of mqtt message broker which will eventually connect to an mqtt broker
-    to publish/subscribe messages.
+    A wrapper class that provides an implementation-agnostic MQTT message broker interface.
+
+    :ivar on_mqtt_connected: Event handler callback, called upon establishing a connection.
+    :type on_mqtt_connected: Function
+    :ivar on_mqtt_disconnected: Event handler callback, called upon a disconnection.
+    :type on_mqtt_disconnected: Function
+    :ivar on_mqtt_message_received: Event handler callback, called upon receiving a message.
+    :type on_mqtt_message_received: Function
     """
 
     def __init__(self, client_id, hostname, username, ca_cert=None):
         """
         Constructor to instantiate a mqtt provider.
-        :param client_id: The id of the client connecting to the broker.
-        :param hostname: hostname or IP address of the remote broker.
-        :param ca_cert: Certificate which can be used to validate a server-side TLS connection.
+        :param str client_id: The id of the client connecting to the broker.
+        :param str hostname: Hostname or IP address of the remote broker.
+        :param str username: Username for login to the remote broker.
+        :param str ca_cert: Certificate which can be used to validate a server-side TLS connection (optional).
         """
         self._client_id = client_id
         self._hostname = hostname
@@ -33,97 +40,112 @@ class MQTTProvider(object):
 
         self.on_mqtt_connected = None
         self.on_mqtt_disconnected = None
-        self.on_mqtt_published = None
-        self.on_mqtt_subscribed = None
-        self.on_mqtt_unsubscribed = None
         self.on_mqtt_message_received = None
+
+        # Maps mid->callback for operations where a control packet has been sent
+        # but the reponse has not yet been received
+        self._pending_operation_callbacks = {}
+
+        # Maps mid->mid for responses received that are in the _pending_operation_callbacks dict.
+        # Necessary because sometimes an operation will complete with a response before the
+        # Paho call returns.
+        # TODO: make this map mid to something more useful (result code?)
+        self._unknown_operation_responses = {}
 
         self._create_mqtt_client()
 
     def _create_mqtt_client(self):
         """
-        Create the MQTT client object and assign all necessary callbacks.
+        Create the MQTT client object and assign all necessary event handler callbacks.
         """
         logger.info("creating mqtt client")
 
-        self._mqtt_client = mqtt.Client(self._client_id, False, protocol=mqtt.MQTTv311)
+        self._mqtt_client = mqtt.Client(
+            client_id=self._client_id, clean_session=False, protocol=mqtt.MQTTv311
+        )
 
-        def on_connect_callback(client, userdata, flags, result_code):
-            logger.info("connected with result code: %s", str(result_code))
+        def on_connect(client, userdata, flags, rc):
+            logger.info("connected with result code: {}".format(rc))
             # TODO: how to do failed connection?
-            try:
-                self.on_mqtt_connected()
-            except:  # noqa: E722 do not use bare 'except'
-                logger.error("Unexpected error calling on_mqtt_connected")
-                logger.error(traceback.format_exc())
+            # MUST do LBYL here to avoid confusion with errors thrown in calling callback
+            if self.on_mqtt_connected:
+                try:
+                    self.on_mqtt_connected()
+                except:  # noqa: E722 do not use bare 'except'
+                    logger.error("Unexpected error calling on_mqtt_connected")
+                    logger.error(traceback.format_exc())
+            else:
+                logger.info("No event handler callback set for on_mqtt_connected")
 
-        def on_disconnect_callback(client, userdata, result_code):
-            logger.info("disconnected with result code: %s", str(result_code))
-            try:
-                self.on_mqtt_disconnected()
-            except:  # noqa: E722 do not use bare 'except'
-                logger.error("Unexpected error calling on_mqtt_disconnected")
-                logger.error(traceback.format_exc())
+        def on_disconnect(client, userdata, rc):
+            logger.info("disconnected with result code: {}".format(rc))
+            # MUST do LBYL here to avoid confusion with errors thrown in calling callback
+            if self.on_mqtt_disconnected:
+                try:
+                    self.on_mqtt_disconnected()
+                except:  # noqa: E722 do not use bare 'except'
+                    logger.error("Unexpected error calling on_mqtt_disconnected")
+                    logger.error(traceback.format_exc())
+            else:
+                logger.info("No event handler callback set for on_mqtt_disconnected")
 
-        def on_publish_callback(client, userdata, mid):
-            logger.info("payload published for %s", str(mid))
+        def on_subscribe(client, userdata, mid, granted_qos):
+            logger.info("suback received for {}".format(mid))
+            # TODO: how to do failure?
+            self._resolve_pending_callback(mid)
+
+        def on_unsubscribe(client, userdata, mid):
+            logger.info("UNSUBACK received for {}".format(mid))
+            # TODO: how to do failure?
+            self._resolve_pending_callback(mid)
+
+        def on_publish(client, userdata, mid):
+            logger.info("payload published for {}".format(mid))
             # TODO: how to do failed publish
-            try:
-                self.on_mqtt_published(mid)
-            except:  # noqa: E722 do not use bare 'except'
-                logger.error("Unexpected error calling on_mqtt_published")
-                logger.error(traceback.format_exc())
+            self._resolve_pending_callback(mid)
 
-        def on_subscribe_callback(client, userdata, mid, granted_qos):
-            logger.info("suback received for %s", str(mid))
-            # TODO: how to do failure?
-            try:
-                self.on_mqtt_subscribed(mid)
-            except:  # noqa: E722 do not use bare 'except'
-                logger.error("Unexpected error calling on_mqtt_subscribed")
-                logger.error(traceback.format_exc())
+        def on_message(client, userdata, mqtt_message):
+            logger.info("message received on {}".format(mqtt_message.topic))
+            # MUST do LBYL here to avoid confusion with errors thrown in calling callback
+            if self.on_mqtt_message_received:
+                try:
+                    # TODO: Why is this returning _topic instead of topic?
+                    self.on_mqtt_message_received(mqtt_message.topic, mqtt_message.payload)
+                except:  # noqa: E722 do not use bare 'except'
+                    logger.error("Unexpected error calling on_mqtt_message_received")
+                    logger.error(traceback.format_exc())
+            else:
+                logger.warning(
+                    "No event handler callback set for on_mqtt_message_received - DROPPING MESSAGE"
+                )
 
-        def on_message_callback(client, userdata, mqtt_message):
-            logger.info("message received on %s", mqtt_message.topic)
-            try:
-                self.on_mqtt_message_received(mqtt_message._topic, mqtt_message.payload)
-            except:  # noqa: E722 do not use bare 'except'
-                logger.error("Unexpected error calling on_mqtt_message_received")
-                logger.error(traceback.format_exc())
-
-        def on_unsubscribe_callback(client, userdata, mid):
-            logger.info("UNSUBACK received for %s", str(mid))
-            # TODO: how to do failure?
-            try:
-                self.on_mqtt_unsubscribed(mid)
-            except:  # noqa: E722 do not use bare 'except'
-                logger.error("Unexpected error calling on_mqtt_unsubscribed")
-                logger.error(traceback.format_exc())
-
-        self._mqtt_client.on_connect = on_connect_callback
-        self._mqtt_client.on_disconnect = on_disconnect_callback
-        self._mqtt_client.on_publish = on_publish_callback
-        self._mqtt_client.on_subscribe = on_subscribe_callback
-        self._mqtt_client.on_message = on_message_callback
-        self._mqtt_client.on_unsubscribe = on_unsubscribe_callback
+        self._mqtt_client.on_connect = on_connect
+        self._mqtt_client.on_disconnect = on_disconnect
+        self._mqtt_client.on_subscribe = on_subscribe
+        self._mqtt_client.on_unsubscribe = on_unsubscribe
+        self._mqtt_client.on_publish = on_publish
+        self._mqtt_client.on_message = on_message
 
         logger.info("Created MQTT provider, assigned callbacks")
 
     def connect(self, password):
         """
-        This method connects the upper transport layer to the mqtt broker.
+        Connect to the MQTT broker, using hostname and username set at instantiation.
+
         This method should be called as an entry point before sending any telemetry.
+
+        :param str password: The password for connecting with the MQTT broker.
         """
         logger.info("connecting to mqtt broker")
 
-        ssl_context = ssl.SSLContext(ssl.PROTOCOL_TLSv1_2)
+        ssl_context = ssl.SSLContext(protocol=ssl.PROTOCOL_TLSv1_2)
         if self._ca_cert:
             ssl_context.load_verify_locations(cadata=self._ca_cert)
         else:
             ssl_context.load_default_certs()
         ssl_context.verify_mode = ssl.CERT_REQUIRED
         ssl_context.check_hostname = True
-        self._mqtt_client.tls_set_context(ssl_context)
+        self._mqtt_client.tls_set_context(context=ssl_context)
         self._mqtt_client.tls_insecure_set(False)
         self._mqtt_client.username_pw_set(username=self._username, password=password)
 
@@ -132,8 +154,11 @@ class MQTTProvider(object):
 
     def reconnect(self, password):
         """
-        This method reconnects the mqtt broker, possibly because of a password (sas) change
-        Connect should have previously been called.
+        Reconnect to the MQTT broker, using username set at instantiation.
+
+        Connect should have previously been called in order to use this function.
+
+        :param str password: The password for reconnecting with the MQTT broker.
         """
         logger.info("reconnecting transport")
         self._mqtt_client.username_pw_set(username=self._username, password=password)
@@ -141,43 +166,96 @@ class MQTTProvider(object):
 
     def disconnect(self):
         """
-        This method disconnects the mqtt provider. This should be called from the upper transport
-        when it wants to disconnect from the mqtt provider.
+        Disconnect from the MQTT broker.
         """
         logger.info("disconnecting transport")
         self._mqtt_client.disconnect()
+        self._mqtt_client.loop_stop()
 
-    def publish(self, topic, message_payload):
+    def subscribe(self, topic, qos=0, callback=None):
         """
-        This method enables the transport to send a message to the message broker.
-        By default the the quality of service level to use is set to 1.
-        :param topic: topic: The topic that the message should be published on.
-        :param message_payload: The actual message to send.
-        :return message ID for the publish request.
+        This method subscribes the client to one topic from the MQTT broker.
+
+        :param str topic: a single string specifying the subscription topic to subscribe to
+        :param int qos: the desired quality of service level for the subscription. Defaults to 0.
+        :param callback: A callback to be triggered upon completion (Optional).
+
+        :return: message ID for the subscribe request
+        :raises: ValueError if qos is not 0, 1 or 2
+        :raises: ValueError if topic is None or has zero string length
+        """
+        logger.info("subscribing to {} with qos {}".format(topic, qos))
+        (result, mid) = self._mqtt_client.subscribe(topic, qos=qos)
+        self._set_operation_callback(mid, callback)
+
+    def unsubscribe(self, topic, callback=None):
+        """
+        Unsubscribe the client from one topic on the MQTT broker.
+
+        :param str topic: a single string which is the subscription topic to unsubscribe from.
+        :param callback: A callback to be triggered upon completion (Optional).
+
+        :raises: ValueError if topic is None or has zero string length
+        """
+        logger.info("unsubscribing from {}".format(topic))
+        (result, mid) = self._mqtt_client.unsubscribe(topic)
+        self._set_operation_callback(mid, callback)
+
+    def publish(self, topic, payload, qos=0, callback=None):
+        """
+        Send a message via the MQTT broker.
+
+        :param str topic: topic: The topic that the message should be published on.
+        :param str payload: The actual message to send.
+        :param int qos: the desired quality of service level for the subscription. Defaults to 0.
+        :param callback: A callback to be triggered upon completion (Optional).
+
+        :raises: ValueError if qos is not 0, 1 or 2
+        :raises: ValueError if topic is None or has zero string length
+        :raises: ValueError if topic contains a wildcard ("+")
+        :raises: ValueError if the length of the payload is greater than 268435455 bytes
         """
         logger.info("sending")
-        message_info = self._mqtt_client.publish(topic=topic, payload=message_payload, qos=1)
-        return message_info.mid
+        message_info = self._mqtt_client.publish(topic=topic, payload=payload, qos=qos)
+        self._set_operation_callback(message_info.mid, callback)
 
-    def subscribe(self, topic, qos=0):
-        """
-        This method subscribes the client to one topic.
-        :param topic: a single string specifying the subscription topic to subscribe to
-        :param qos: the desired quality of service level for the subscription. Defaults to 0.
-        :return: message ID for the subscribe request
-        Raises a ValueError if qos is not 0, 1 or 2, or if topic is None or has zero string length,
-        """
-        logger.info("subscribing to %s with qos %s", topic, str(qos))
-        (result, mid) = self._mqtt_client.subscribe(topic, qos)
-        return mid
+    def _set_operation_callback(self, mid, callback):
+        if mid in self._unknown_operation_responses:
+            # If response already came back, trigger the callback
+            logger.info("Response for MID: {} was received early - triggering callback".format(mid))
+            del self._unknown_operation_responses[mid]
+            # MUST do LBYL here to avoid confusion with errors thrown in calling callback
+            if callback:
+                try:
+                    callback()
+                except:  # noqa: E722 do not use bare 'except'
+                    logger.error("Unexpected error calling callback for MID: {}".format(mid))
+                    logger.error(traceback.format_exc())
+            else:
+                logger.info("No callback for MID: {}".format(mid))
+        else:
+            # Otherwise, set the callback to use later
+            logger.info("Waiting for response on MID: {}".format(mid))
+            self._pending_operation_callbacks[mid] = callback
 
-    def unsubscribe(self, topic):
-        """
-        Unsubscribe the client from one topic.
-        :param topic: a single string which is the subscription topic to unsubscribe from.
-        :return: mid the message ID for the unsubscribe request.
-        Raises a ValueError if topic is None or has zero string length, or is not a string.
-        """
-        logger.info("unsubscribing from %s", topic)
-        (result, mid) = self._mqtt_client.unsubscribe(topic)
-        return mid
+    def _resolve_pending_callback(self, mid):
+        if mid in self._pending_operation_callbacks:
+            # If mid is known, trigger it's associated callback
+            logger.info(
+                "Response received for recognized MID: {} - triggering callback".format(mid)
+            )
+            callback = self._pending_operation_callbacks[mid]
+            del self._pending_operation_callbacks[mid]
+            # MUST do LBYL here to avoid confusion with errors thrown in calling callback
+            if callback:
+                try:
+                    callback()
+                except:  # noqa: E722 do not use bare 'except'
+                    logger.error("Unexpected error calling callback for MID: {}".format(mid))
+                    logger.error(traceback.format_exc())
+            else:
+                logger.info("No callback set for MID: {}".format(mid))
+        else:
+            # Otherwise, store the mid as an unknown response
+            logger.warning("Response received for unknown MID: {}".format(mid))
+            self._unknown_operation_responses[mid] = mid  # TODO: set something more useful here

--- a/azure-iot-device/azure/iot/device/iothub/transport/mqtt/mqtt_transport.py
+++ b/azure-iot-device/azure/iot/device/iothub/transport/mqtt/mqtt_transport.py
@@ -361,7 +361,7 @@ class MQTTTransport(AbstractTransport):
 
     def _execute_action(self, action):
         """
-        Execute an action from the action queue. This is called when the transport is connected and the
+        Execute an action from the action queue.  This is called when the transport is connected and the
         state machine is able to execute individual actions.
 
         :param TransportAction action: object containing the details of the action to be executed

--- a/azure-iot-device/azure/iot/device/iothub/transport/mqtt/mqtt_transport.py
+++ b/azure-iot-device/azure/iot/device/iothub/transport/mqtt/mqtt_transport.py
@@ -72,6 +72,8 @@ class uses the following conventions:
 
 """
 
+QOS_SEND_MESSAGE = 1
+QOS_SUBSCRIBE = 1
 
 TOPIC_POS_DEVICE = 4
 TOPIC_POS_MODULE = 6
@@ -102,6 +104,7 @@ class SendMessageAction(TransportAction):
     def __init__(self, message, callback):
         TransportAction.__init__(self, callback)
         self.message = message
+        self.qos = QOS_SEND_MESSAGE
 
 
 class SubscribeAction(TransportAction):
@@ -109,10 +112,10 @@ class SubscribeAction(TransportAction):
     TransportAction object used to subscribe to a specific MQTT topic
     """
 
-    def __init__(self, topic, qos, callback):
+    def __init__(self, topic, callback):
         TransportAction.__init__(self, callback)
         self.topic = topic
-        self.qos = qos
+        self.qos = QOS_SUBSCRIBE
 
 
 class UnsubscribeAction(TransportAction):
@@ -149,15 +152,6 @@ class MQTTTransport(AbstractTransport):
         # Currently, we use a queue, which is FIFO, but the actual order doesn't matter
         # since each action stands on its own.
         self._pending_action_queue = queue.Queue()
-
-        # Object which maps mid->callback for actions which are in flight.  This is
-        # used to call back into the caller to indicate that an action is complete.
-        self._in_progress_actions = {}
-
-        # Map of responses we receive with a MID that is not in the _in_progress_actions map.
-        # We need this because sometimes a SUBSCRIBE or a PUBLISH will complete before the call
-        # to subscribe() or publish() returns.
-        self._responses_with_unknown_mid = {}
 
         self._connect_callback = None
         self._disconnect_callback = None
@@ -329,40 +323,6 @@ class MQTTTransport(AbstractTransport):
             self._disconnect_callback = None
             callback()
 
-    def _on_provider_publish_complete(self, mid):
-        """
-        Callback that is called by the provider when it receives a PUBACK from the service
-
-        :param mid: message id that was returned by the provider when `publish` was called.  This is used to tie the
-            PUBLISH to the PUBACK.
-        """
-        if mid in self._in_progress_actions:
-            callback = self._in_progress_actions[mid]
-            del self._in_progress_actions[mid]
-            callback()
-        else:
-            logger.warning("PUBACK received with unknown MID: %s", str(mid))
-            self._responses_with_unknown_mid[
-                mid
-            ] = mid  # storing MID for now.  will probably store result code later.
-
-    def _on_provider_subscribe_complete(self, mid):
-        """
-        Callback that is called by the provider when it receives a SUBACK from the service
-
-        :param mid: message id that was returned by the provider when `subscribe` was called.  This is used to tie the
-            SUBSCRIBE to the SUBACK.
-        """
-        if mid in self._in_progress_actions:
-            callback = self._in_progress_actions[mid]
-            del self._in_progress_actions[mid]
-            callback()
-        else:
-            logger.warning("SUBACK received with unknown MID: %s", str(mid))
-            self._responses_with_unknown_mid[
-                mid
-            ] = mid  # storing MID for now.  will probably store result code later.
-
     def _on_provider_message_received_callback(self, topic, payload):
         """
         Callback that is called by the provider when a message is received.  This message can be any MQTT message,
@@ -370,42 +330,23 @@ class MQTTTransport(AbstractTransport):
         a method invocation.  This function needs to decide what kind of message it is based on the topic name and
         take the correct action.
 
-        :param topic: MQTT topic name that the message arrived on
-        :param payload: Payload of the message
+        :param str topic: MQTT topic name that the message arrived on
+        :param bytes payload: Payload of the message as a bytestring
         """
-        logger.info("Message received on topic %s", topic)
+        logger.info("Message received on topic {}".format(topic))
         message_received = Message(payload)
-        # TODO : Discuss everything in bytes , need to be changed, specially the topic
-        topic_str = topic.decode("utf-8")
-        topic_parts = topic_str.split("/")
+        topic_parts = topic.split("/")
 
-        if _is_input_topic(topic_str):
+        if _is_input_topic(topic):
             input_name = topic_parts[TOPIC_POS_INPUT_NAME]
             message_received.input_name = input_name
             _extract_properties(topic_parts[TOPIC_POS_MODULE], message_received)
             self.on_transport_input_message_received(input_name, message_received)
-        elif _is_c2d_topic(topic_str):
+        elif _is_c2d_topic(topic):
             _extract_properties(topic_parts[TOPIC_POS_DEVICE], message_received)
             self.on_transport_c2d_message_received(message_received)
         else:
             pass  # is there any other case
-
-    def _on_provider_unsubscribe_complete(self, mid):
-        """
-        Callback that is called by the provider when it receives an UNSUBACK from the service
-
-        :param mid: message id that was returned by the provider when `unsubscribe` was called.  This is used to tie the
-            UNSUBSCRIBE to the UNSUBACK.
-        """
-        if mid in self._in_progress_actions:
-            callback = self._in_progress_actions[mid]
-            del self._in_progress_actions[mid]
-            callback()
-        else:
-            logger.warning("UNSUBACK received with unknown MID: %s", str(mid))
-            self._responses_with_unknown_mid[
-                mid
-            ] = mid  # storing MID for now.  will probably store result code later.
 
     def _add_action_to_queue(self, event_data):
         """
@@ -420,7 +361,7 @@ class MQTTTransport(AbstractTransport):
 
     def _execute_action(self, action):
         """
-        Execute an action from the action queue.  This is called when the transport is connected and the
+        Execute an action from the action queue. This is called when the transport is connected and the
         state machine is able to execute individual actions.
 
         :param TransportAction action: object containing the details of the action to be executed
@@ -432,41 +373,32 @@ class MQTTTransport(AbstractTransport):
             encoded_topic = _encode_properties(
                 message_to_send, self._get_telemetry_topic_for_publish()
             )
-            mid = self._mqtt_provider.publish(encoded_topic, message_to_send.data)
-            if mid in self._responses_with_unknown_mid:
-                del self._responses_with_unknown_mid[mid]
-                action.callback()
-            else:
-                self._in_progress_actions[mid] = action.callback
+            self._mqtt_provider.publish(
+                topic=encoded_topic,
+                payload=message_to_send.data,
+                qos=action.qos,
+                callback=action.callback,
+            )
 
         elif isinstance(action, SubscribeAction):
             logger.info("running SubscribeAction topic=%s qos=%s", action.topic, action.qos)
-            mid = self._mqtt_provider.subscribe(action.topic, action.qos)
-            logger.info("subscribe mid = %s", mid)
-            if mid in self._responses_with_unknown_mid:
-                del self._responses_with_unknown_mid[mid]
-                action.callback()
-            else:
-                self._in_progress_actions[mid] = action.callback
+            self._mqtt_provider.subscribe(
+                topic=action.topic, qos=action.qos, callback=action.callback
+            )
 
         elif isinstance(action, UnsubscribeAction):
             logger.info("running UnsubscribeAction")
-            mid = self._mqtt_provider.unsubscribe(action.topic)
-            if mid in self._responses_with_unknown_mid:
-                del self._responses_with_unknown_mid[mid]
-                action.callback()
-            else:
-                self._in_progress_actions[mid] = action.callback
+            self._mqtt_provider.unsubscribe(topic=action.topic, callback=action.callback)
 
         elif isinstance(action, MethodReponseAction):
             logger.info("running MethodResponseAction")
             topic = "TODO"
-            mid = self._mqtt_provider.publish(topic, action.method_response)
-            if mid in self._responses_with_unknown_mid:
-                del self._responses_with_unknown_mid[mid]
-                action.callback()
-            else:
-                self._in_progress_actions[mid] = action.callback
+            self._mqtt_provider.publish(
+                topic=topic,
+                payload=action.method_response,
+                qos=action.qos,
+                callback=action.callback,
+            )
 
         else:
             logger.error("Removed unknown action type from queue.")
@@ -512,13 +444,12 @@ class MQTTTransport(AbstractTransport):
         else:
             ca_cert = None
 
-        self._mqtt_provider = MQTTProvider(client_id, hostname, username, ca_cert=ca_cert)
+        self._mqtt_provider = MQTTProvider(
+            client_id=client_id, hostname=hostname, username=username, ca_cert=ca_cert
+        )
 
         self._mqtt_provider.on_mqtt_connected = self._on_provider_connect_complete
         self._mqtt_provider.on_mqtt_disconnected = self._on_provider_disconnect_complete
-        self._mqtt_provider.on_mqtt_published = self._on_provider_publish_complete
-        self._mqtt_provider.on_mqtt_subscribed = self._on_provider_subscribe_complete
-        self._mqtt_provider.on_mqtt_unsubscribed = self._on_provider_unsubscribe_complete
         self._mqtt_provider.on_mqtt_message_received = self._on_provider_message_received_callback
 
     def _get_topic_base(self):
@@ -583,7 +514,7 @@ class MQTTTransport(AbstractTransport):
 
         :param callback: callback which is called when the message publish has been acknowledged by the service.
         """
-        action = SendMessageAction(message, callback)
+        action = SendMessageAction(message=message, callback=callback)
         self._trig_add_action_to_pending_queue(action)
 
     def send_output_event(self, message, callback=None):
@@ -592,7 +523,7 @@ class MQTTTransport(AbstractTransport):
 
         :param callback: callback which is called when the message publish has been acknowledged by the service.
         """
-        action = SendMessageAction(message, callback)
+        action = SendMessageAction(message=message, callback=callback)
         self._trig_add_action_to_pending_queue(action)
 
     def send_method_response(self, method, payload, status, callback=None):
@@ -646,9 +577,7 @@ class MQTTTransport(AbstractTransport):
 
         :param callback: callback which is called when the feature is enabled
         """
-        action = SubscribeAction(
-            topic=self._get_input_topic_for_subscribe(), qos=1, callback=callback
-        )
+        action = SubscribeAction(topic=self._get_input_topic_for_subscribe(), callback=callback)
         self._trig_add_action_to_pending_queue(action)
         self.feature_enabled[constant.INPUT_MSG] = True
 
@@ -668,9 +597,7 @@ class MQTTTransport(AbstractTransport):
 
         :param callback: callback which is called when the feature is enabled
         """
-        action = SubscribeAction(
-            topic=self._get_c2d_topic_for_subscribe(), qos=1, callback=callback
-        )
+        action = SubscribeAction(topic=self._get_c2d_topic_for_subscribe(), callback=callback)
         self._trig_add_action_to_pending_queue(action)
         self.feature_enabled[constant.C2D_MSG] = True
 
@@ -684,14 +611,13 @@ class MQTTTransport(AbstractTransport):
         self._trig_add_action_to_pending_queue(action)
         self.feature_enabled[constant.C2D_MSG] = False
 
-    def _enable_methods(self, callback=None, qos=1):
+    def _enable_methods(self, callback=None):
         """
         Helper function to enable methods
 
         :param callback: callback which is called when the feature is enabled.
-        :param qos: Quality of Serivce level
         """
-        action = SubscribeAction(self._get_method_topic_for_subscribe(), qos, callback)
+        action = SubscribeAction(self._get_method_topic_for_subscribe(), callback)
         self._trig_add_action_to_pending_queue(action)
         self.feature_enabled[constant.METHODS] = True
 

--- a/azure-iot-device/tests/iothub/transport/mqtt/test_mqtt_provider.py
+++ b/azure-iot-device/tests/iothub/transport/mqtt/test_mqtt_provider.py
@@ -8,7 +8,7 @@ from azure.iot.device.iothub.transport.mqtt.mqtt_provider import MQTTProvider
 import paho.mqtt.client as mqtt
 import ssl
 import pytest
-from mock import MagicMock, patch
+
 
 fake_hostname = "beauxbatons.academy-net"
 fake_device_id = "MyFirebolt"
@@ -16,156 +16,1110 @@ fake_password = "Fortuna Major"
 fake_username = fake_hostname + "/" + fake_device_id
 new_fake_password = "new fake password"
 fake_topic = "fake_topic"
+fake_payload = "Tarantallegra"
 fake_qos = 1
 fake_mid = 52
 fake_rc = 0
 
 
-@patch.object(ssl, "SSLContext")
-@patch.object(mqtt, "Client")
-def test_connect_triggers_client_connect(MockMqttClient, MockSsl):
-    mqtt_provider = MQTTProvider(fake_device_id, fake_hostname, fake_username)
-    mqtt_provider.connect(fake_password)
+class DummyException(Exception):
+    pass
 
-    MockMqttClient.assert_called_once_with(fake_device_id, False, protocol=4)
-    mock_mqtt_client = MockMqttClient.return_value
 
-    MockSsl.assert_called_once_with(ssl.PROTOCOL_TLSv1_2)
+@pytest.fixture
+def mock_mqtt_client(mocker):
+    mock = mocker.patch.object(mqtt, "Client")
+    mock_mqtt_client = mock.return_value
+    mock_mqtt_client.subscribe = mocker.MagicMock(return_value=(fake_rc, fake_mid))
+    mock_mqtt_client.unsubscribe = mocker.MagicMock(return_value=(fake_rc, fake_mid))
+    return mock_mqtt_client
 
-    assert mock_mqtt_client.tls_set_context.call_count == 1
-    context = mock_mqtt_client.tls_set_context.call_args[0][0]
-    assert context.check_hostname is True
-    assert context.verify_mode == ssl.CERT_REQUIRED
-    context.load_default_certs.assert_called_once_with()
-    mock_mqtt_client.tls_insecure_set.assert_called_once_with(False)
-    mock_mqtt_client.username_pw_set.assert_called_once_with(
-        username=fake_username, password=fake_password
+
+@pytest.fixture
+def provider(mock_mqtt_client):
+    # Implicitly imports the mocked Paho MQTT Client from mock_mqtt_client
+    return MQTTProvider(client_id=fake_device_id, hostname=fake_hostname, username=fake_username)
+
+
+@pytest.mark.describe("MQTT Provider - Instantiation")
+class TestInstantiation(object):
+    @pytest.mark.it("Creates an instance of the Paho MQTT Client")
+    def test_instantiates_mqtt_client(self, mocker):
+        mock_mqtt_client_constructor = mocker.patch.object(mqtt, "Client")
+
+        MQTTProvider(client_id=fake_device_id, hostname=fake_hostname, username=fake_username)
+
+        assert mock_mqtt_client_constructor.call_count == 1
+        assert mock_mqtt_client_constructor.call_args == mocker.call(
+            client_id=fake_device_id, clean_session=False, protocol=mqtt.MQTTv311
+        )
+
+    @pytest.mark.it("Sets Paho MQTT Client callbacks")
+    def test_sets_paho_callbacks(self, mocker):
+        mock_mqtt_client = mocker.patch.object(mqtt, "Client").return_value
+
+        MQTTProvider(client_id=fake_device_id, hostname=fake_hostname, username=fake_username)
+
+        assert callable(mock_mqtt_client.on_connect)
+        assert callable(mock_mqtt_client.on_disconnect)
+        assert callable(mock_mqtt_client.on_subscribe)
+        assert callable(mock_mqtt_client.on_unsubscribe)
+        assert callable(mock_mqtt_client.on_publish)
+        assert callable(mock_mqtt_client.on_message)
+
+    @pytest.mark.it("Initializes event handler callbacks to 'None'")
+    def test_handler_callbacks_set_to_none(self, mocker):
+        mocker.patch.object(mqtt, "Client")
+
+        provider = MQTTProvider(
+            client_id=fake_device_id, hostname=fake_hostname, username=fake_username
+        )
+
+        assert provider.on_mqtt_connected is None
+        assert provider.on_mqtt_disconnected is None
+        assert provider.on_mqtt_message_received is None
+
+    @pytest.mark.it("Initializes internal operation tracking structures")
+    def test_operation_infrastructure_set_up(self, mocker):
+        provider = MQTTProvider(
+            client_id=fake_device_id, hostname=fake_hostname, username=fake_username
+        )
+
+        assert provider._pending_operation_callbacks == {}
+        assert provider._unknown_operation_responses == {}
+
+
+@pytest.mark.describe("MQTT Provider - Connect")
+class TestConnect(object):
+    @pytest.mark.it("Configures TLS/SSL context")
+    def test_configures_tls_context(self, mocker, mock_mqtt_client, provider):
+        mock_ssl_context_constructor = mocker.patch.object(ssl, "SSLContext")
+        mock_ssl_context = mock_ssl_context_constructor.return_value
+
+        provider.connect(fake_password)
+
+        # Verify correctness of TLS/SSL Context
+        assert mock_ssl_context_constructor.call_count == 1
+        assert mock_ssl_context_constructor.call_args == mocker.call(protocol=ssl.PROTOCOL_TLSv1_2)
+        assert mock_ssl_context.check_hostname is True
+        assert mock_ssl_context.verify_mode == ssl.CERT_REQUIRED
+
+        # Verify correctness of MQTT Client TLS config
+        assert mock_mqtt_client.tls_set_context.call_count == 1
+        assert mock_mqtt_client.tls_set_context.call_args == mocker.call(context=mock_ssl_context)
+        assert mock_mqtt_client.tls_insecure_set.call_count == 1
+        assert mock_mqtt_client.tls_insecure_set.call_args == mocker.call(False)
+
+    @pytest.mark.it(
+        "Configures TLS/SSL context using default certificates if Provider not instantiated with a CA certificate"
     )
-    mock_mqtt_client.connect.assert_called_once_with(host=fake_hostname, port=8883)
-    mock_mqtt_client.loop_start.assert_called_once_with()
+    def test_configures_tls_context_with_default_certs(self, mocker, mock_mqtt_client, provider):
+        mock_ssl_context_constructor = mocker.patch.object(ssl, "SSLContext")
+        mock_ssl_context = mock_ssl_context_constructor.return_value
 
-    assert mock_mqtt_client.on_connect is not None
-    assert mock_mqtt_client.on_disconnect is not None
-    assert mock_mqtt_client.on_publish is not None
-    assert mock_mqtt_client.on_subscribe is not None
+        provider = MQTTProvider(
+            client_id=fake_device_id, hostname=fake_hostname, username=fake_username
+        )
+        provider.connect(fake_password)
 
+        assert mock_ssl_context.load_default_certs.call_count == 1
+        assert mock_ssl_context.load_default_certs.call_args == mocker.call()
 
-@patch.object(mqtt, "Client")
-@pytest.mark.parametrize(
-    "client_callback_name, client_callback_args, provider_callback_name, provider_callback_args",
-    [
-        pytest.param(
-            "on_connect",
-            [None, None, None, 0],
-            "on_mqtt_connected",
-            [],
-            id="on_connect => on_mqtt_connected",
-        ),
-        pytest.param(
-            "on_disconnect",
-            [None, None, 0],
-            "on_mqtt_disconnected",
-            [],
-            id="on_disconnect => on_mqtt_disconnected",
-        ),
-        pytest.param(
-            "on_publish",
-            [None, None, 9],
-            "on_mqtt_published",
-            [9],
-            id="on_publish => on_mqtt_published",
-        ),
-        pytest.param(
-            "on_subscribe",
-            [None, None, 1234, 1],
-            "on_mqtt_subscribed",
-            [1234],
-            id="on_subscribe => on_mqtt_subscribed",
-        ),
-        pytest.param(
-            "on_unsubscribe",
-            [None, None, 1235],
-            "on_mqtt_unsubscribed",
-            [1235],
-            id="on_unsubscribe => on_mqtt_unsubscribed",
-        ),
-    ],
-)
-def test_mqtt_client_callback_triggers_provider_callback(
-    MockMqttClient,
-    client_callback_name,
-    client_callback_args,
-    provider_callback_name,
-    provider_callback_args,
-):
-    mock_mqtt_client = MockMqttClient.return_value
-
-    mqtt_provider = MQTTProvider(fake_device_id, fake_hostname, fake_username)
-    stub_provider_callback = MagicMock()
-    setattr(mqtt_provider, provider_callback_name, stub_provider_callback)
-
-    getattr(mock_mqtt_client, client_callback_name)(*client_callback_args)
-
-    stub_provider_callback.assert_called_once_with(*provider_callback_args)
-
-
-@patch.object(mqtt, "Client")
-def test_disconnect_calls_loopstop_on_mqttclient(MockMqttClient):
-    mock_mqtt_client = MockMqttClient.return_value
-
-    mqtt_provider = MQTTProvider(fake_device_id, fake_hostname, fake_username)
-    mqtt_provider.disconnect()
-
-    mock_mqtt_client.disconnect.assert_called_once_with()
-
-
-@patch.object(mqtt, "Client")
-def test_publish_calls_publish_on_mqtt_client(MockMqttClient):
-    mock_mqtt_client = MockMqttClient.return_value
-    mock_mqtt_client.publish = MagicMock(return_value=mqtt.MQTTMessageInfo(fake_mid))
-
-    topic = "topic/"
-    event = "Tarantallegra"
-
-    mqtt_provider = MQTTProvider(fake_device_id, fake_hostname, fake_username)
-    pub_mid = mqtt_provider.publish(topic, event)
-
-    assert pub_mid == fake_mid
-    mock_mqtt_client.publish.assert_called_once_with(topic=topic, payload=event, qos=1)
-
-
-@patch.object(mqtt, "Client")
-def test_reconnect_calls_username_pw_set_and_reconnect_on_mqtt_client(MockMqttClient):
-    mock_mqtt_client = MockMqttClient.return_value
-
-    mqtt_provider = MQTTProvider(fake_device_id, fake_hostname, fake_username)
-    mqtt_provider.reconnect(new_fake_password)
-
-    mock_mqtt_client.username_pw_set.assert_called_once_with(
-        username=fake_username, password=new_fake_password
+    @pytest.mark.it(
+        "Configures TLS/SSL context with provided CA certificates if Provider instantiated with a CA certificate"
     )
-    mock_mqtt_client.reconnect.assert_called_once_with()
+    def test_configures_tls_context_with_ca_certs(self, mocker, mock_mqtt_client, provider):
+        mock_ssl_context_constructor = mocker.patch.object(ssl, "SSLContext")
+        mock_ssl_context = mock_ssl_context_constructor.return_value
+        ca_cert = "dummy_certificate"
+
+        provider = MQTTProvider(
+            client_id=fake_device_id,
+            hostname=fake_hostname,
+            username=fake_username,
+            ca_cert=ca_cert,
+        )
+        provider.connect(fake_password)
+
+        assert mock_ssl_context.load_verify_locations.call_count == 1
+        assert mock_ssl_context.load_verify_locations.call_args == mocker.call(cadata=ca_cert)
+
+    @pytest.mark.it("Sets username and password")
+    def test_sets_username_and_password(self, mocker, mock_mqtt_client, provider):
+        provider.connect(fake_password)
+
+        assert mock_mqtt_client.username_pw_set.call_count == 1
+        assert mock_mqtt_client.username_pw_set.call_args == mocker.call(
+            username=fake_username, password=fake_password
+        )
+
+    @pytest.mark.it("Connects via Paho")
+    def test_calls_paho_connect(self, mocker, mock_mqtt_client, provider):
+        provider.connect(fake_password)
+
+        assert mock_mqtt_client.connect.call_count == 1
+        assert mock_mqtt_client.connect.call_args == mocker.call(host=fake_hostname, port=8883)
+
+    @pytest.mark.it("Starts MQTT Network Loop")
+    def test_calls_loop_start(self, mocker, mock_mqtt_client, provider):
+        provider.connect(fake_password)
+
+        assert mock_mqtt_client.loop_start.call_count == 1
+        assert mock_mqtt_client.loop_start.call_args == mocker.call()
+
+    @pytest.mark.it("Triggers on_mqtt_connected event handler callback upon connect completion")
+    def test_calls_event_handler_callback(self, mocker, mock_mqtt_client, provider):
+        callback = mocker.MagicMock()
+        provider.on_mqtt_connected = callback
+
+        # Initiate connect
+        provider.connect(fake_password)
+
+        # Manually trigger Paho on_connect event_handler
+        mock_mqtt_client.on_connect(client=mock_mqtt_client, userdata=None, flags=None, rc=fake_rc)
+
+        # Verify provider.on_mqtt_connected was called
+        assert callback.call_count == 1
+        assert callback.call_args == mocker.call()
+
+    @pytest.mark.it(
+        "Skips on_mqtt_connected event handler callback if set to 'None' upon connect completion"
+    )
+    def test_skips_none_event_handler_callback(self, mocker, mock_mqtt_client, provider):
+        assert provider.on_mqtt_connected is None
+
+        provider.connect(fake_password)
+
+        mock_mqtt_client.on_connect(client=mock_mqtt_client, userdata=None, flags=None, rc=fake_rc)
+
+        # No further asserts required - this is a test to show that it skips a callback.
+        # Not raising an exception == test passed
+
+    @pytest.mark.it("Recovers from exception in on_mqtt_connected event handler callback")
+    def test_event_handler_callback_raises_exception(self, mocker, mock_mqtt_client, provider):
+        event_cb = mocker.MagicMock(side_effect=DummyException)
+        provider.on_mqtt_connected = event_cb
+
+        provider.connect(fake_password)
+        mock_mqtt_client.on_connect(client=mock_mqtt_client, userdata=None, flags=None, rc=fake_rc)
+
+        # Callback was called, but exception did not propagate
+        assert event_cb.call_count == 1
 
 
-@patch.object(mqtt, "Client")
-def test_subscribe_calls_subscribe_on_mqtt_client(MockMqttClient):
-    mock_mqtt_client = MockMqttClient.return_value
-    mock_mqtt_client.subscribe = MagicMock(return_value=(fake_rc, fake_mid))
+@pytest.mark.describe("MQTT Provider - Reconnect")
+class TestReconnect(object):
+    @pytest.mark.it("Sets username and password")
+    def test_sets_username_and_password(self, mocker, mock_mqtt_client, provider):
+        provider.reconnect(fake_password)
 
-    mqtt_provider = MQTTProvider(fake_device_id, fake_hostname, fake_username)
-    sub_mid = mqtt_provider.subscribe(fake_topic, fake_qos)
+        assert mock_mqtt_client.username_pw_set.call_count == 1
+        assert mock_mqtt_client.username_pw_set.call_args == mocker.call(
+            username=fake_username, password=fake_password
+        )
 
-    assert sub_mid == fake_mid
-    mock_mqtt_client.subscribe.assert_called_once_with(fake_topic, fake_qos)
+    @pytest.mark.it("Reconnects with Paho")
+    def test_calls_paho_reconnect(self, mocker, mock_mqtt_client, provider):
+        provider.reconnect(fake_password)
+
+        assert mock_mqtt_client.reconnect.call_count == 1
+        assert mock_mqtt_client.reconnect.call_args == mocker.call()
+
+    @pytest.mark.it(
+        "Triggers on_mqtt_connected event handler callback upon completion of user-driven reconnect"
+    )
+    def test_calls_event_handler_callback_user_driven(self, mocker, mock_mqtt_client, provider):
+        callback = mocker.MagicMock()
+        provider.on_mqtt_connected = callback
+
+        # Initiate reconnect
+        provider.reconnect(fake_password)
+
+        # Manually trigger Paho on_connect event_handler
+        mock_mqtt_client.on_connect(client=mock_mqtt_client, userdata=None, flags=None, rc=fake_rc)
+
+        # Verify provider.on_mqtt_connected was called
+        assert callback.call_count == 1
+        assert callback.call_args == mocker.call()
+
+    @pytest.mark.it(
+        "Triggers on_mqtt_connected event handler callback upon completion of externally-driven reconnect"
+    )
+    def test_calls_event_handler_callback_externally_driven(
+        self, mocker, mock_mqtt_client, provider
+    ):
+        callback = mocker.MagicMock()
+        provider.on_mqtt_connected = callback
+
+        # Manually trigger Paho on_connect event_handler
+        mock_mqtt_client.on_connect(client=mock_mqtt_client, userdata=None, flags=None, rc=fake_rc)
+
+        # Verify provider.on_mqtt_connected was called
+        assert callback.call_count == 1
+        assert callback.call_args == mocker.call()
+
+    @pytest.mark.it(
+        "Skips on_mqtt_connected event handler callback if set to 'None' upon reconnect completion"
+    )
+    def test_skips_none_event_handler_callback(self, mocker, mock_mqtt_client, provider):
+        assert provider.on_mqtt_connected is None
+
+        provider.reconnect(fake_password)
+
+        mock_mqtt_client.on_connect(client=mock_mqtt_client, userdata=None, flags=None, rc=fake_rc)
+
+        # No further asserts required - this is a test to show that it skips a callback.
+        # Not raising an exception == test passed
+
+    @pytest.mark.it("Recovers from exception in on_mqtt_connected event handler callback")
+    def test_event_handler_callback_raises_exception(self, mocker, mock_mqtt_client, provider):
+        event_cb = mocker.MagicMock(side_effect=DummyException)
+        provider.on_mqtt_connected = event_cb
+
+        provider.reconnect(fake_password)
+        mock_mqtt_client.on_connect(client=mock_mqtt_client, userdata=None, flags=None, rc=fake_rc)
+
+        # Callback was called, but exception did not propagate
+        assert event_cb.call_count == 1
 
 
-@patch.object(mqtt, "Client")
-def test_unsubscribe_calls_unsubscribe_on_mqtt_client(MockMqttClient):
-    mock_mqtt_client = MockMqttClient.return_value
-    mock_mqtt_client.unsubscribe = MagicMock(return_value=(fake_rc, fake_mid))
+@pytest.mark.describe("MQTT Provider - Disconnect")
+class TestDisconnect(object):
+    @pytest.mark.it("Disconnects with Paho")
+    def test_calls_paho_disconnect(self, mocker, mock_mqtt_client, provider):
+        provider.disconnect()
 
-    mqtt_provider = MQTTProvider(fake_device_id, fake_hostname, fake_username)
-    unsub_mid = mqtt_provider.unsubscribe(fake_topic)
+        assert mock_mqtt_client.disconnect.call_count == 1
+        assert mock_mqtt_client.disconnect.call_args == mocker.call()
 
-    assert unsub_mid == fake_mid
-    mock_mqtt_client.unsubscribe.assert_called_once_with(fake_topic)
+    @pytest.mark.it("Stops MQTT Network Loop")
+    def test_calls_loop_stop(self, mocker, mock_mqtt_client, provider):
+        provider.disconnect()
+
+        assert mock_mqtt_client.loop_stop.call_count == 1
+        assert mock_mqtt_client.loop_stop.call_args == mocker.call()
+
+    @pytest.mark.it(
+        "Triggers on_mqtt_disconnected event handler callback upon completion of user-driven disconnect "
+    )
+    def test_calls_event_handler_callback_user_driven(self, mocker, mock_mqtt_client, provider):
+        callback = mocker.MagicMock()
+        provider.on_mqtt_disconnected = callback
+
+        # Initiate disconnect
+        provider.disconnect()
+
+        # Manually trigger Paho on_disconnect event_handler
+        mock_mqtt_client.on_disconnect(client=mock_mqtt_client, userdata=None, rc=fake_rc)
+
+        # Verify provider.on_mqtt_disconnected was called
+        assert callback.call_count == 1
+        assert callback.call_args == mocker.call()
+
+    @pytest.mark.it(
+        "Triggers on_mqtt_disconnected event handler callback upon completion of externally-driven disconnect"
+    )
+    def test_calls_event_handler_callback_externally_driven(
+        self, mocker, mock_mqtt_client, provider
+    ):
+        callback = mocker.MagicMock()
+        provider.on_mqtt_disconnected = callback
+
+        # Initiate disconnect
+        provider.disconnect()
+
+        # Manually trigger Paho on_connect event_handler
+        mock_mqtt_client.on_disconnect(client=mock_mqtt_client, userdata=None, rc=fake_rc)
+
+        # Verify provider.on_mqtt_connected was called
+        assert callback.call_count == 1
+        assert callback.call_args == mocker.call()
+
+    @pytest.mark.it(
+        "Skips on_mqtt_disconnected event handler callback if set to 'None' upon disconnect completion"
+    )
+    def test_skips_none_event_handler_callback(self, mocker, mock_mqtt_client, provider):
+        assert provider.on_mqtt_disconnected is None
+
+        provider.disconnect()
+
+        mock_mqtt_client.on_disconnect(client=mock_mqtt_client, userdata=None, rc=fake_rc)
+
+        # No further asserts required - this is a test to show that it skips a callback.
+        # Not raising an exception == test passed
+
+    @pytest.mark.it("Recovers from exception in on_mqtt_disconnected event handler callback")
+    def test_event_handler_callback_raises_exception(self, mocker, mock_mqtt_client, provider):
+        event_cb = mocker.MagicMock(side_effect=DummyException)
+        provider.on_mqtt_disconnected = event_cb
+
+        provider.disconnect()
+        mock_mqtt_client.on_disconnect(client=mock_mqtt_client, userdata=None, rc=fake_rc)
+
+        # Callback was called, but exception did not propagate
+        assert event_cb.call_count == 1
+
+
+@pytest.mark.describe("MQTT Provider - Subscribe")
+class TestSubscribe(object):
+    @pytest.mark.it("Subscribes with Paho")
+    @pytest.mark.parametrize(
+        "qos",
+        [pytest.param(0, id="QoS 0"), pytest.param(1, id="QoS 1"), pytest.param(2, id="QoS 2")],
+    )
+    def test_calls_paho_subscribe(self, mocker, mock_mqtt_client, provider, qos):
+        provider.subscribe(fake_topic, qos=qos)
+
+        assert mock_mqtt_client.subscribe.call_count == 1
+        assert mock_mqtt_client.subscribe.call_args == mocker.call(fake_topic, qos=qos)
+
+    @pytest.mark.it("Raises ValueError on invalid QoS")
+    @pytest.mark.parametrize("qos", [pytest.param(-1, id="QoS < 0"), pytest.param(3, id="QoS > 2")])
+    def test_raises_value_error_invalid_qos(self, qos):
+        # Manually instantiate Provider, do NOT mock paho client (paho generates this error)
+        provider = MQTTProvider(
+            client_id=fake_device_id, hostname=fake_hostname, username=fake_username
+        )
+        with pytest.raises(ValueError):
+            provider.subscribe(fake_topic, qos=qos)
+
+    @pytest.mark.it("Raises ValueError on invalid topic string")
+    @pytest.mark.parametrize("topic", [pytest.param(None), pytest.param("", id="Empty string")])
+    def test_raises_value_error_invalid_topic(self, topic):
+        # Manually instantiate Provider, do NOT mock paho client (paho generates this error)
+        provider = MQTTProvider(
+            client_id=fake_device_id, hostname=fake_hostname, username=fake_username
+        )
+        with pytest.raises(ValueError):
+            provider.subscribe(topic, qos=fake_qos)
+
+    @pytest.mark.it("Triggers callback upon subscribe completion")
+    def test_triggers_callback_upon_paho_on_subscribe_event(
+        self, mocker, mock_mqtt_client, provider
+    ):
+        callback = mocker.MagicMock()
+        mock_mqtt_client.subscribe.return_value = (fake_rc, fake_mid)
+
+        # Initiate subscribe
+        provider.subscribe(topic=fake_topic, qos=fake_qos, callback=callback)
+
+        # Check callback is stored as pending, but not called
+        assert callback.call_count == 0
+        assert provider._pending_operation_callbacks == {fake_mid: callback}
+        assert provider._unknown_operation_responses == {}
+
+        # Manually trigger Paho on_subscribe event handler
+        mock_mqtt_client.on_subscribe(
+            client=mock_mqtt_client, userdata=None, mid=fake_mid, granted_qos=fake_qos
+        )
+
+        # Check callback has now been called, and stored values cleared
+        assert callback.call_count == 1
+        assert provider._pending_operation_callbacks == {}
+        assert provider._unknown_operation_responses == {}
+
+    @pytest.mark.it(
+        "Triggers callback upon subscribe completion when Paho event handler triggered early"
+    )
+    def test_triggers_callback_when_paho_on_subscribe_event_called_early(
+        self, mocker, mock_mqtt_client, provider
+    ):
+        callback = mocker.MagicMock()
+
+        def trigger_early_on_subscribe(topic, qos):
+
+            # Trigger on_subscribe before returning mid
+            mock_mqtt_client.on_subscribe(
+                client=mock_mqtt_client, userdata=None, mid=fake_mid, granted_qos=fake_qos
+            )
+
+            # Check mid has been stored as an unknown response, callback not yet called
+            assert callback.call_count == 0
+            assert provider._pending_operation_callbacks == {}
+            assert provider._unknown_operation_responses == {fake_mid: fake_mid}
+
+            return (fake_rc, fake_mid)
+
+        mock_mqtt_client.subscribe.side_effect = trigger_early_on_subscribe
+
+        # Initiate subscribe
+        provider.subscribe(topic=fake_topic, qos=fake_qos, callback=callback)
+
+        # Check callback has now been called, and stored values cleared
+        assert callback.call_count == 1
+        assert provider._pending_operation_callbacks == {}
+        assert provider._unknown_operation_responses == {}
+
+    @pytest.mark.it("Skips callback that is set to 'None' upon subscribe completion")
+    def test_none_callback_upon_paho_on_subscribe_event(self, mocker, mock_mqtt_client, provider):
+        callback = None
+        mock_mqtt_client.subscribe.return_value = (fake_rc, fake_mid)
+
+        # Initiate subscribe
+        provider.subscribe(topic=fake_topic, qos=fake_qos, callback=callback)
+
+        # Check that callback (None) has been stored
+        assert provider._pending_operation_callbacks == {fake_mid: callback}
+        assert provider._unknown_operation_responses == {}
+
+        # Manually trigger Paho on_subscribe event handler
+        mock_mqtt_client.on_subscribe(
+            client=mock_mqtt_client, userdata=None, mid=fake_mid, granted_qos=fake_qos
+        )
+
+        # Check that callback (None) has now been cleared
+        assert provider._pending_operation_callbacks == {}
+        assert provider._unknown_operation_responses == {}
+
+    @pytest.mark.it(
+        "Skips callback that is set to 'None' upon subscribe completion when Paho event handler triggered early"
+    )
+    def test_none_callback_when_paho_on_subscribe_event_called_early(
+        self, mocker, mock_mqtt_client, provider
+    ):
+        callback = None
+
+        def trigger_early_on_subscribe(topic, qos):
+
+            # Trigger on_subscribe before returning mid
+            mock_mqtt_client.on_subscribe(
+                client=mock_mqtt_client, userdata=None, mid=fake_mid, granted_qos=fake_qos
+            )
+
+            # Check mid has been stored as an unknown response, callback not yet called
+            assert provider._pending_operation_callbacks == {}
+            assert provider._unknown_operation_responses == {fake_mid: fake_mid}
+
+            return (fake_rc, fake_mid)
+
+        mock_mqtt_client.subscribe.side_effect = trigger_early_on_subscribe
+
+        # Initiate subscribe
+        provider.subscribe(topic=fake_topic, qos=fake_qos, callback=callback)
+
+        # Check callback (None) has now been cleared
+        assert provider._pending_operation_callbacks == {}
+        assert provider._unknown_operation_responses == {}
+
+    @pytest.mark.it(
+        "Handles multiple callbacks from multiple subscribe operations that complete out of order"
+    )
+    def test_multiple_callbacks(self, mocker, mock_mqtt_client, provider):
+        callback1 = mocker.MagicMock()
+        callback2 = mocker.MagicMock()
+        callback3 = mocker.MagicMock()
+
+        mid1 = 1
+        mid2 = 2
+        mid3 = 3
+
+        mock_mqtt_client.subscribe.side_effect = [(fake_rc, mid1), (fake_rc, mid2), (fake_rc, mid3)]
+
+        # Initiate subscribe (1 -> 2 -> 3)
+        provider.subscribe(topic=fake_topic, qos=fake_qos, callback=callback1)
+        provider.subscribe(topic=fake_topic, qos=fake_qos, callback=callback2)
+        provider.subscribe(topic=fake_topic, qos=fake_qos, callback=callback3)
+
+        # Check callbacks have not yet been called
+        assert callback1.call_count == 0
+        assert callback2.call_count == 0
+        assert callback3.call_count == 0
+
+        # Manually trigger Paho on_subscribe event handler (2 -> 3 -> 1)
+        mock_mqtt_client.on_subscribe(
+            client=mock_mqtt_client, userdata=None, mid=mid2, granted_qos=fake_qos
+        )
+        assert callback1.call_count == 0
+        assert callback2.call_count == 1
+        assert callback3.call_count == 0
+
+        mock_mqtt_client.on_subscribe(
+            client=mock_mqtt_client, userdata=None, mid=mid3, granted_qos=fake_qos
+        )
+        assert callback1.call_count == 0
+        assert callback2.call_count == 1
+        assert callback3.call_count == 1
+
+        mock_mqtt_client.on_subscribe(
+            client=mock_mqtt_client, userdata=None, mid=mid1, granted_qos=fake_qos
+        )
+        assert callback1.call_count == 1
+        assert callback2.call_count == 1
+        assert callback3.call_count == 1
+
+    @pytest.mark.it("Recovers from exception in callback")
+    def test_callback_raises_exception(self, mocker, mock_mqtt_client, provider):
+        callback = mocker.MagicMock(side_effect=DummyException)
+        mock_mqtt_client.subscribe.return_value = (fake_rc, fake_mid)
+
+        provider.subscribe(topic=fake_topic, qos=fake_qos, callback=callback)
+        mock_mqtt_client.on_subscribe(
+            client=mock_mqtt_client, userdata=None, mid=fake_mid, granted_qos=fake_qos
+        )
+
+        # Callback was called, but exception did not propagate
+        assert callback.call_count == 1
+
+    @pytest.mark.it("Recovers from exception in callback when Paho event handler triggered early")
+    def test_callback_rasies_exception_when_paho_on_subscribe_triggered_early(
+        self, mocker, mock_mqtt_client, provider
+    ):
+        callback = mocker.MagicMock(side_effect=DummyException)
+
+        def trigger_early_on_subscribe(topic, qos):
+            mock_mqtt_client.on_subscribe(
+                client=mock_mqtt_client, userdata=None, mid=fake_mid, granted_qos=fake_qos
+            )
+
+            # Should not have yet called callback
+            assert callback.call_count == 0
+
+            return (fake_rc, fake_mid)
+
+        mock_mqtt_client.subscribe.side_effect = trigger_early_on_subscribe
+
+        # Initiate subscribe
+        provider.subscribe(topic=fake_topic, qos=fake_qos, callback=callback)
+
+        # Callback was called, but exception did not propagate
+        assert callback.call_count == 1
+
+
+@pytest.mark.describe("MQTT Provider - Unsubscribe")
+class TestUnsubscribe(object):
+    @pytest.mark.it("Unsubscribes with Paho")
+    def test_calls_paho_unsubscribe(self, mocker, mock_mqtt_client, provider):
+        provider.unsubscribe(fake_topic)
+
+        assert mock_mqtt_client.unsubscribe.call_count == 1
+        assert mock_mqtt_client.unsubscribe.call_args == mocker.call(fake_topic)
+
+    @pytest.mark.it("Raises ValueError on invalid topic string")
+    @pytest.mark.parametrize("topic", [pytest.param(None), pytest.param("", id="Empty string")])
+    def test_raises_value_error_invalid_topic(self, topic):
+        # Manually instantiate Provider, do NOT mock paho client (paho generates this error)
+        provider = MQTTProvider(
+            client_id=fake_device_id, hostname=fake_hostname, username=fake_username
+        )
+        with pytest.raises(ValueError):
+            provider.unsubscribe(topic)
+
+    @pytest.mark.it("Triggers callback upon unsubscribe completion")
+    def test_triggers_callback_upon_paho_on_unsubscribe_event(
+        self, mocker, mock_mqtt_client, provider
+    ):
+        callback = mocker.MagicMock()
+        mock_mqtt_client.unsubscribe.return_value = (fake_rc, fake_mid)
+
+        # Initiate unsubscribe
+        provider.unsubscribe(topic=fake_topic, callback=callback)
+
+        # Check callback is stored as pending, but not called
+        assert callback.call_count == 0
+        assert provider._pending_operation_callbacks == {fake_mid: callback}
+        assert provider._unknown_operation_responses == {}
+
+        # Manually trigger Paho on_unsubscribe event handler
+        mock_mqtt_client.on_unsubscribe(client=mock_mqtt_client, userdata=None, mid=fake_mid)
+
+        # Check callback has now been called, and stored values cleared
+        assert callback.call_count == 1
+        assert provider._pending_operation_callbacks == {}
+        assert provider._unknown_operation_responses == {}
+
+    @pytest.mark.it(
+        "Triggers callback upon unsubscribe completion when Paho event handler triggered early"
+    )
+    def test_triggers_callback_when_paho_on_unsubscribe_event_called_early(
+        self, mocker, mock_mqtt_client, provider
+    ):
+        callback = mocker.MagicMock()
+
+        def trigger_early_on_unsubscribe(topic):
+
+            # Trigger on_unsubscribe before returning mid
+            mock_mqtt_client.on_unsubscribe(client=mock_mqtt_client, userdata=None, mid=fake_mid)
+
+            # Check mid has been stored as an unknown response, callback not yet called
+            assert callback.call_count == 0
+            assert provider._pending_operation_callbacks == {}
+            assert provider._unknown_operation_responses == {fake_mid: fake_mid}
+
+            return (fake_rc, fake_mid)
+
+        mock_mqtt_client.unsubscribe.side_effect = trigger_early_on_unsubscribe
+
+        # Initiate unsubscribe
+        provider.unsubscribe(topic=fake_topic, callback=callback)
+
+        # Check callback has now been called, and stored values cleared
+        assert callback.call_count == 1
+        assert provider._pending_operation_callbacks == {}
+        assert provider._unknown_operation_responses == {}
+
+    @pytest.mark.it("Skips callback that is set to 'None' upon unsubscribe completion")
+    def test_none_callback_upon_paho_on_unsubscribe_event(self, mocker, mock_mqtt_client, provider):
+        callback = None
+        mock_mqtt_client.unsubscribe.return_value = (fake_rc, fake_mid)
+
+        # Initiate unsubscribe
+        provider.unsubscribe(topic=fake_topic, callback=callback)
+
+        # Check that callback (None) has been stored
+        assert provider._pending_operation_callbacks == {fake_mid: callback}
+        assert provider._unknown_operation_responses == {}
+
+        # Manually trigger Paho on_unsubscribe event handler
+        mock_mqtt_client.on_unsubscribe(client=mock_mqtt_client, userdata=None, mid=fake_mid)
+
+        # Check that callback (None) has now been cleared
+        assert provider._pending_operation_callbacks == {}
+        assert provider._unknown_operation_responses == {}
+
+    @pytest.mark.it(
+        "Skips callback that is set to 'None' upon unsubscribe completion when Paho event handler triggered early"
+    )
+    def test_none_callback_when_paho_on_unsubscribe_event_called_early(
+        self, mocker, mock_mqtt_client, provider
+    ):
+        callback = None
+
+        def trigger_early_on_unsubscribe(topic):
+
+            # Trigger on_unsubscribe before returning mid
+            mock_mqtt_client.on_unsubscribe(client=mock_mqtt_client, userdata=None, mid=fake_mid)
+
+            # Check mid has been stored as an unknown response, callback not yet called
+            assert provider._pending_operation_callbacks == {}
+            assert provider._unknown_operation_responses == {fake_mid: fake_mid}
+
+            return (fake_rc, fake_mid)
+
+        mock_mqtt_client.unsubscribe.side_effect = trigger_early_on_unsubscribe
+
+        # Initiate unsubscribe
+        provider.unsubscribe(topic=fake_topic, callback=callback)
+
+        # Check callback (None) has now been cleared
+        assert provider._pending_operation_callbacks == {}
+        assert provider._unknown_operation_responses == {}
+
+    @pytest.mark.it(
+        "Handles multiple callbacks from multiple unsubscribe operations that complete out of order"
+    )
+    def test_multiple_callbacks(self, mocker, mock_mqtt_client, provider):
+        callback1 = mocker.MagicMock()
+        callback2 = mocker.MagicMock()
+        callback3 = mocker.MagicMock()
+
+        mid1 = 1
+        mid2 = 2
+        mid3 = 3
+
+        mock_mqtt_client.unsubscribe.side_effect = [
+            (fake_rc, mid1),
+            (fake_rc, mid2),
+            (fake_rc, mid3),
+        ]
+
+        # Initiate unsubscribe (1 -> 2 -> 3)
+        provider.unsubscribe(topic=fake_topic, callback=callback1)
+        provider.unsubscribe(topic=fake_topic, callback=callback2)
+        provider.unsubscribe(topic=fake_topic, callback=callback3)
+
+        # Check callbacks have not yet been called
+        assert callback1.call_count == 0
+        assert callback2.call_count == 0
+        assert callback3.call_count == 0
+
+        # Manually trigger Paho on_unsubscribe event handler (2 -> 3 -> 1)
+        mock_mqtt_client.on_unsubscribe(client=mock_mqtt_client, userdata=None, mid=mid2)
+        assert callback1.call_count == 0
+        assert callback2.call_count == 1
+        assert callback3.call_count == 0
+
+        mock_mqtt_client.on_unsubscribe(client=mock_mqtt_client, userdata=None, mid=mid3)
+        assert callback1.call_count == 0
+        assert callback2.call_count == 1
+        assert callback3.call_count == 1
+
+        mock_mqtt_client.on_unsubscribe(client=mock_mqtt_client, userdata=None, mid=mid1)
+        assert callback1.call_count == 1
+        assert callback2.call_count == 1
+        assert callback3.call_count == 1
+
+    @pytest.mark.it("Recovers from exception in callback")
+    def test_callback_raises_exception(self, mocker, mock_mqtt_client, provider):
+        callback = mocker.MagicMock(side_effect=DummyException)
+        mock_mqtt_client.unsubscribe.return_value = (fake_rc, fake_mid)
+
+        provider.unsubscribe(topic=fake_topic, callback=callback)
+        mock_mqtt_client.on_unsubscribe(client=mock_mqtt_client, userdata=None, mid=fake_mid)
+
+        # Callback was called, but exception did not propagate
+        assert callback.call_count == 1
+
+    @pytest.mark.it("Recovers from exception in callback when Paho event handler triggered early")
+    def test_callback_rasies_exception_when_paho_on_unsubscribe_triggered_early(
+        self, mocker, mock_mqtt_client, provider
+    ):
+        callback = mocker.MagicMock(side_effect=DummyException)
+
+        def trigger_early_on_unsubscribe(topic):
+            mock_mqtt_client.on_unsubscribe(client=mock_mqtt_client, userdata=None, mid=fake_mid)
+
+            # Should not have yet called callback
+            assert callback.call_count == 0
+
+            return (fake_rc, fake_mid)
+
+        mock_mqtt_client.unsubscribe.side_effect = trigger_early_on_unsubscribe
+
+        # Initiate unsubscribe
+        provider.unsubscribe(topic=fake_topic, callback=callback)
+
+        # Callback was called, but exception did not propagate
+        assert callback.call_count == 1
+
+
+@pytest.mark.describe("MQTT Provider - Publish")
+class TestPublish(object):
+    @pytest.fixture
+    def message_info(self, mocker):
+        mi = mqtt.MQTTMessageInfo(fake_mid)
+        mi.rc = fake_rc
+        return mi
+
+    @pytest.mark.it("Publishes with Paho")
+    @pytest.mark.parametrize(
+        "qos",
+        [pytest.param(0, id="QoS 0"), pytest.param(1, id="QoS 1"), pytest.param(2, id="QoS 2")],
+    )
+    def test_calls_paho_publish(self, mocker, mock_mqtt_client, provider, qos):
+        provider.publish(topic=fake_topic, payload=fake_payload, qos=qos)
+
+        assert mock_mqtt_client.publish.call_count == 1
+        assert mock_mqtt_client.publish.call_args == mocker.call(
+            topic=fake_topic, payload=fake_payload, qos=qos
+        )
+
+    @pytest.mark.it("Raises ValueError on invalid QoS")
+    @pytest.mark.parametrize("qos", [pytest.param(-1, id="QoS < 0"), pytest.param(3, id="Qos > 2")])
+    def test_raises_value_error_invalid_qos(self, qos):
+        # Manually instantiate Provider, do NOT mock paho client (paho generates this error)
+        provider = MQTTProvider(
+            client_id=fake_device_id, hostname=fake_hostname, username=fake_username
+        )
+        with pytest.raises(ValueError):
+            provider.publish(topic=fake_topic, payload=fake_payload, qos=qos)
+
+    @pytest.mark.it("Raises ValueError on invalid topic string")
+    @pytest.mark.parametrize(
+        "topic",
+        [
+            pytest.param(None),
+            pytest.param("", id="Empty string"),
+            pytest.param("+", id="Contains wildcard (+)"),
+        ],
+    )
+    def test_raises_value_error_invalid_topic(self, topic):
+        # Manually instantiate Provider, do NOT mock paho client (paho generates this error)
+        provider = MQTTProvider(
+            client_id=fake_device_id, hostname=fake_hostname, username=fake_username
+        )
+        with pytest.raises(ValueError):
+            provider.publish(topic=topic, payload=fake_payload, qos=fake_qos)
+
+    @pytest.mark.it("Raises ValueError on invalid payload")
+    @pytest.mark.parametrize("payload", [str(b"0" * 268435456)], ids=["Payload > 268435455 bytes"])
+    def test_raises_value_error_invalid_payload(self, payload):
+        # Manually instantiate Provider, do NOT mock paho client (paho generates this error)
+        provider = MQTTProvider(
+            client_id=fake_device_id, hostname=fake_hostname, username=fake_username
+        )
+        with pytest.raises(ValueError):
+            provider.publish(topic=fake_topic, payload=payload, qos=fake_qos)
+
+    @pytest.mark.it("Triggers callback upon publish completion")
+    def test_triggers_callback_upon_paho_on_publish_event(
+        self, mocker, mock_mqtt_client, provider, message_info
+    ):
+        callback = mocker.MagicMock()
+        mock_mqtt_client.publish.return_value = message_info
+
+        # Initiate publish
+        provider.publish(topic=fake_topic, payload=fake_payload, callback=callback)
+
+        # Check callback is stored as pending, but not called
+        assert callback.call_count == 0
+        assert provider._pending_operation_callbacks == {message_info.mid: callback}
+        assert provider._unknown_operation_responses == {}
+
+        # Manually trigger Paho on_publish event handler
+        mock_mqtt_client.on_publish(client=mock_mqtt_client, userdata=None, mid=message_info.mid)
+
+        # Check callback has now been called, and stored values cleared
+        assert callback.call_count == 1
+        assert provider._pending_operation_callbacks == {}
+        assert provider._unknown_operation_responses == {}
+
+    @pytest.mark.it(
+        "Triggers callback upon publish completion when Paho event handler triggered early"
+    )
+    def test_triggers_callback_when_paho_on_publish_event_called_early(
+        self, mocker, mock_mqtt_client, provider, message_info
+    ):
+        callback = mocker.MagicMock()
+
+        def trigger_early_on_publish(topic, payload, qos):
+
+            # Trigger on_publish before returning message_info
+            mock_mqtt_client.on_publish(
+                client=mock_mqtt_client, userdata=None, mid=message_info.mid
+            )
+
+            # Check mid has been stored as an unknown response, callback not yet called
+            assert callback.call_count == 0
+            assert provider._pending_operation_callbacks == {}
+            assert provider._unknown_operation_responses == {message_info.mid: message_info.mid}
+
+            return message_info
+
+        mock_mqtt_client.publish.side_effect = trigger_early_on_publish
+
+        # Initiate publish
+        provider.publish(topic=fake_topic, payload=fake_payload, callback=callback)
+
+        # Check callback has now been called, and stored values cleared
+        assert callback.call_count == 1
+        assert provider._pending_operation_callbacks == {}
+        assert provider._unknown_operation_responses == {}
+
+    @pytest.mark.it("Skips callback that is set to 'None' upon publish completion")
+    def test_none_callback_upon_paho_on_publish_event(
+        self, mocker, mock_mqtt_client, provider, message_info
+    ):
+        mock_mqtt_client.publish.return_value = message_info
+        callback = None
+
+        # Initiate publish
+        provider.publish(topic=fake_topic, payload=fake_payload, callback=callback)
+
+        # Check that callback (None) has been stored
+        assert provider._pending_operation_callbacks == {message_info.mid: callback}
+        assert provider._unknown_operation_responses == {}
+
+        # Manually trigger Paho on_publish event handler
+        mock_mqtt_client.on_publish(client=mock_mqtt_client, userdata=None, mid=message_info.mid)
+
+        # Check that callback (None) has now been cleared
+        assert provider._pending_operation_callbacks == {}
+        assert provider._unknown_operation_responses == {}
+
+    @pytest.mark.it(
+        "Skips callback that is set to 'None' upon publish completion when Paho event handler triggered early"
+    )
+    def test_none_callback_when_paho_on_publish_event_called_early(
+        self, mocker, mock_mqtt_client, provider, message_info
+    ):
+        callback = None
+
+        def trigger_early_on_publish(topic, payload, qos):
+
+            # Trigger on_publish before returning message_info
+            mock_mqtt_client.on_publish(
+                client=mock_mqtt_client, userdata=None, mid=message_info.mid
+            )
+
+            # Check mid has been stored as an unknown response, callback not yet called
+            assert provider._pending_operation_callbacks == {}
+            assert provider._unknown_operation_responses == {message_info.mid: message_info.mid}
+
+            return message_info
+
+        mock_mqtt_client.publish.side_effect = trigger_early_on_publish
+
+        # Initiate publish
+        provider.publish(topic=fake_topic, payload=fake_payload, callback=callback)
+
+        # Check callback (None) has now been cleared
+        assert provider._pending_operation_callbacks == {}
+        assert provider._unknown_operation_responses == {}
+
+    @pytest.mark.it(
+        "Handles multiple callbacks from multiple publish operations that complete out of order"
+    )
+    def test_multiple_callbacks(self, mocker, mock_mqtt_client, provider):
+        callback1 = mocker.MagicMock()
+        callback2 = mocker.MagicMock()
+        callback3 = mocker.MagicMock()
+
+        mid1 = 1
+        mid2 = 2
+        mid3 = 3
+
+        mock_mqtt_client.publish.side_effect = [
+            mqtt.MQTTMessageInfo(mid1),
+            mqtt.MQTTMessageInfo(mid2),
+            mqtt.MQTTMessageInfo(mid3),
+        ]
+
+        # Initiate publish (1 -> 2 -> 3)
+        provider.publish(topic=fake_topic, payload=fake_payload, callback=callback1)
+        provider.publish(topic=fake_topic, payload=fake_payload, callback=callback2)
+        provider.publish(topic=fake_topic, payload=fake_payload, callback=callback3)
+
+        # Check callbacks have not yet been called
+        assert callback1.call_count == 0
+        assert callback2.call_count == 0
+        assert callback3.call_count == 0
+
+        # Manually trigger Paho on_publish event handler (2 -> 3 -> 1)
+        mock_mqtt_client.on_publish(client=mock_mqtt_client, userdata=None, mid=mid2)
+        assert callback1.call_count == 0
+        assert callback2.call_count == 1
+        assert callback3.call_count == 0
+
+        mock_mqtt_client.on_publish(client=mock_mqtt_client, userdata=None, mid=mid3)
+        assert callback1.call_count == 0
+        assert callback2.call_count == 1
+        assert callback3.call_count == 1
+
+        mock_mqtt_client.on_publish(client=mock_mqtt_client, userdata=None, mid=mid1)
+        assert callback1.call_count == 1
+        assert callback2.call_count == 1
+        assert callback3.call_count == 1
+
+    @pytest.mark.it("Recovers from exception in callback")
+    def test_callback_raises_exception(self, mocker, mock_mqtt_client, provider, message_info):
+        callback = mocker.MagicMock(side_effect=DummyException)
+        mock_mqtt_client.publish.return_value = message_info
+
+        provider.publish(topic=fake_topic, payload=fake_payload, callback=callback)
+        mock_mqtt_client.on_publish(client=mock_mqtt_client, userdata=None, mid=message_info.mid)
+
+        # Callback was called, but exception did not propagate
+        assert callback.call_count == 1
+
+    @pytest.mark.it("Recovers from exception in callback when Paho event handler triggered early")
+    def test_callback_rasies_exception_when_paho_on_publish_triggered_early(
+        self, mocker, mock_mqtt_client, provider, message_info
+    ):
+        callback = mocker.MagicMock(side_effect=DummyException)
+
+        def trigger_early_on_publish(topic, payload, qos):
+            mock_mqtt_client.on_publish(
+                client=mock_mqtt_client, userdata=None, mid=message_info.mid
+            )
+
+            # Should not have yet called callback
+            assert callback.call_count == 0
+
+            return message_info
+
+        mock_mqtt_client.publish.side_effect = trigger_early_on_publish
+
+        # Initiate publish
+        provider.publish(topic=fake_topic, payload=fake_payload, callback=callback)
+
+        # Callback was called, but exception did not propagate
+        assert callback.call_count == 1
+
+
+@pytest.mark.describe("MQTT Provider - Message Received")
+class TestMessageReceived(object):
+    @pytest.fixture()
+    def message(self):
+        message = mqtt.MQTTMessage(mid=fake_mid, topic=fake_topic.encode())
+        message.payload = fake_payload
+        message.qos = fake_qos
+        return message
+
+    @pytest.mark.it(
+        "Triggers on_mqtt_message_received event handler callback upon receiving message"
+    )
+    def test_calls_event_handler_callback(self, mocker, mock_mqtt_client, provider, message):
+        callback = mocker.MagicMock()
+        provider.on_mqtt_message_received = callback
+
+        # Manually trigger Paho on_message event_handler
+        mock_mqtt_client.on_message(client=mock_mqtt_client, userdata=None, mqtt_message=message)
+
+        # Verify provider.on_mqtt_message_received was called
+        assert callback.call_count == 1
+        assert callback.call_args == mocker.call(message.topic, message.payload)
+
+    @pytest.mark.it(
+        "Skips on_mqtt_message_received event handler callback if set to 'None' upon receiving message"
+    )
+    def test_skips_none_event_handler_callback(self, mocker, mock_mqtt_client, provider, message):
+        assert provider.on_mqtt_message_received is None
+
+        # Manually trigger Paho on_message event_handler
+        mock_mqtt_client.on_message(client=mock_mqtt_client, userdata=None, mqtt_message=message)
+
+        # No further asserts required - this is a test to show that it skips a callback.
+        # Not raising an exception == test passed
+
+    @pytest.mark.it("Recovers from exception in on_mqtt_message_received event handler callback")
+    def test_event_handler_callback_raises_exception(
+        self, mocker, mock_mqtt_client, provider, message
+    ):
+        event_cb = mocker.MagicMock(side_effect=DummyException)
+        provider.on_mqtt_message_received = event_cb
+
+        mock_mqtt_client.on_message(client=mock_mqtt_client, userdata=None, mqtt_message=message)
+
+        # Callback was called, but exception did not propagate
+        assert event_cb.call_count == 1
+
+
+@pytest.mark.describe("MQTT Provider - Misc.")
+class TestMisc(object):
+    @pytest.mark.it(
+        "Handles multiple callbacks from multiple different types of operations that complete out of order"
+    )
+    def test_multiple_callbacks_multiple_ops(self, mocker, mock_mqtt_client, provider):
+        callback1 = mocker.MagicMock()
+        callback2 = mocker.MagicMock()
+        callback3 = mocker.MagicMock()
+
+        mid1 = 1
+        mid2 = 2
+        mid3 = 3
+
+        topic1 = "topic1"
+        topic2 = "topic2"
+        topic3 = "topic3"
+
+        mock_mqtt_client.subscribe.return_value = (fake_rc, mid1)
+        mock_mqtt_client.publish.return_value = mqtt.MQTTMessageInfo(mid2)
+        mock_mqtt_client.unsubscribe.return_value = (fake_rc, mid3)
+
+        # Initiate operations (1 -> 2 -> 3)
+        provider.subscribe(topic=topic1, qos=fake_qos, callback=callback1)
+        provider.publish(topic=topic2, payload="payload", qos=fake_qos, callback=callback2)
+        provider.unsubscribe(topic=topic3, callback=callback3)
+
+        # Check callbacks have not yet been called
+        assert callback1.call_count == 0
+        assert callback2.call_count == 0
+        assert callback3.call_count == 0
+
+        # Manually trigger Paho on_unsubscribe event handler (2 -> 3 -> 1)
+        mock_mqtt_client.on_publish(client=mock_mqtt_client, userdata=None, mid=mid2)
+        assert callback1.call_count == 0
+        assert callback2.call_count == 1
+        assert callback3.call_count == 0
+
+        mock_mqtt_client.on_unsubscribe(client=mock_mqtt_client, userdata=None, mid=mid3)
+        assert callback1.call_count == 0
+        assert callback2.call_count == 1
+        assert callback3.call_count == 1
+
+        mock_mqtt_client.on_subscribe(
+            client=mock_mqtt_client, userdata=None, mid=mid1, granted_qos=fake_qos
+        )
+        assert callback1.call_count == 1
+        assert callback2.call_count == 1
+        assert callback3.call_count == 1

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ py==1.6.0
 pytest==3.8.0
 pytest-mock==1.10.0
 pytest-asyncio==0.10.0; python_version >= '3.5'
-pytest-testdox
+pytest-testdox>=1.1.1
 pytest-cov==2.6.0
 wheel==0.32.1
 paho-mqtt==1.4.0


### PR DESCRIPTION
* Moved all reference to Message ID (a Paho specific concept) to the Provider
* Added callbacks parameters to some Provider APIs
* Improved test coverage in the Provider
* Added exception handling to callbacks in Provider
* Updated pytest-testdox requirement due to bugfix
* Improved documentation in Provider