### PR TITLE
Renamed MQTTClientOperator -> MQTTTransport

### DIFF
--- a/azure-iot-device/azure/iot/device/common/mqtt_transport.py
+++ b/azure-iot-device/azure/iot/device/common/mqtt_transport.py
@@ -13,7 +13,7 @@ import traceback
 logger = logging.getLogger(__name__)
 
 
-class MQTTClientOperator(object):
+class MQTTTransport(object):
     """
     A wrapper class that provides an implementation-agnostic MQTT message broker interface.
 


### PR DESCRIPTION
In preparation for bringing in the HTTP pipeline, I renamed the Operator to Transport.