### PR TITLE
[REFACTOR] PipelineStage._run_op() --> PipelineStage._execute_op()

### DIFF
--- a/azure-iot-device/azure/iot/device/common/pipeline/operation_flow.py
+++ b/azure-iot-device/azure/iot/device/common/pipeline/operation_flow.py
@@ -163,7 +163,7 @@ def delegate_to_different_op(stage, original_op, new_op):
 
     This is useful when a generic operation (such as "enable feature") needs to be
     converted into a more specific operation (such as "subscribe to mqtt topic").
-    In that case, a stage's _run_op function would call this function passing in
+    In that case, a stage's _execute_op function would call this function passing in
     the original "enable feature" op and the new "subscribe to mqtt topic"
     op.  This function will pass the "subscribe" down. When the "subscribe" op
     is completed, this function will cause the original op to complete.

--- a/azure-iot-device/azure/iot/device/common/pipeline/pipeline_stages_mqtt.py
+++ b/azure-iot-device/azure/iot/device/common/pipeline/pipeline_stages_mqtt.py
@@ -50,7 +50,7 @@ class MQTTTransportStage(PipelineStage):
             operation_flow.complete_op(stage=self, op=op)
 
     @pipeline_thread.runs_on_pipeline_thread
-    def _run_op(self, op):
+    def _execute_op(self, op):
         if isinstance(op, pipeline_ops_mqtt.SetMQTTConnectionArgsOperation):
             # pipeline_ops_mqtt.SetMQTTConnectionArgsOperation is where we create our MQTTTransport object and set
             # all of its properties.

--- a/azure-iot-device/azure/iot/device/iothub/pipeline/pipeline_stages_iothub.py
+++ b/azure-iot-device/azure/iot/device/iothub/pipeline/pipeline_stages_iothub.py
@@ -27,7 +27,7 @@ class UseAuthProviderStage(PipelineStage):
     """
 
     @pipeline_thread.runs_on_pipeline_thread
-    def _run_op(self, op):
+    def _execute_op(self, op):
         if isinstance(op, pipeline_ops_iothub.SetAuthProviderOperation):
             auth_provider = op.auth_provider
             operation_flow.delegate_to_different_op(
@@ -71,7 +71,7 @@ class HandleTwinOperationsStage(PipelineStage):
     """
 
     @pipeline_thread.runs_on_pipeline_thread
-    def _run_op(self, op):
+    def _execute_op(self, op):
         def map_twin_error(original_op, twin_op):
             if twin_op.error:
                 original_op.error = twin_op.error

--- a/azure-iot-device/azure/iot/device/iothub/pipeline/pipeline_stages_iothub_mqtt.py
+++ b/azure-iot-device/azure/iot/device/iothub/pipeline/pipeline_stages_iothub_mqtt.py
@@ -35,7 +35,7 @@ class IoTHubMQTTConverterStage(PipelineStage):
         self.feature_to_topic = {}
 
     @pipeline_thread.runs_on_pipeline_thread
-    def _run_op(self, op):
+    def _execute_op(self, op):
 
         if isinstance(op, pipeline_ops_iothub.SetIoTHubConnectionArgsOperation):
             self.device_id = op.device_id

--- a/azure-iot-device/azure/iot/device/provisioning/pipeline/pipeline_stages_provisioning.py
+++ b/azure-iot-device/azure/iot/device/provisioning/pipeline/pipeline_stages_provisioning.py
@@ -18,7 +18,7 @@ class UseSecurityClientStage(PipelineStage):
     """
 
     @pipeline_thread.runs_on_pipeline_thread
-    def _run_op(self, op):
+    def _execute_op(self, op):
         if isinstance(op, pipeline_ops_provisioning.SetSymmetricKeySecurityClientOperation):
 
             security_client = op.security_client

--- a/azure-iot-device/azure/iot/device/provisioning/pipeline/pipeline_stages_provisioning_mqtt.py
+++ b/azure-iot-device/azure/iot/device/provisioning/pipeline/pipeline_stages_provisioning_mqtt.py
@@ -35,7 +35,7 @@ class ProvisioningMQTTConverterStage(PipelineStage):
         self.action_to_topic = {}
 
     @pipeline_thread.runs_on_pipeline_thread
-    def _run_op(self, op):
+    def _execute_op(self, op):
 
         if isinstance(op, pipeline_ops_provisioning.SetProvisioningClientConnectionArgsOperation):
             # get security client args from above, save some, use some to build topic names,

--- a/azure-iot-device/tests/common/pipeline/helpers.py
+++ b/azure-iot-device/tests/common/pipeline/helpers.py
@@ -58,10 +58,10 @@ def make_mock_stage(mocker, stage_to_make):
     """
     # because PipelineStage is abstract, we need something concrete
     class NextStageForTest(pipeline_stages_base.PipelineStage):
-        def _run_op(self, op):
+        def _execute_op(self, op):
             operation_flow.pass_op_to_next_stage(self, op)
 
-    def stage_run_op(self, op):
+    def stage_execute_op(self, op):
         if getattr(op, "action", None) is None or op.action == "pass":
             operation_flow.complete_op(self, op)
         elif op.action == "fail" or op.action == "exception":
@@ -75,12 +75,12 @@ def make_mock_stage(mocker, stage_to_make):
 
     first_stage = stage_to_make()
     first_stage.unhandled_error_handler = mocker.Mock()
-    mocker.spy(first_stage, "_run_op")
+    mocker.spy(first_stage, "_execute_op")
     mocker.spy(first_stage, "run_op")
 
     next_stage = NextStageForTest()
-    next_stage._run_op = functools.partial(stage_run_op, next_stage)
-    mocker.spy(next_stage, "_run_op")
+    next_stage._execute_op = functools.partial(stage_execute_op, next_stage)
+    mocker.spy(next_stage, "_execute_op")
     mocker.spy(next_stage, "run_op")
 
     first_stage.next = next_stage

--- a/azure-iot-device/tests/common/pipeline/pipeline_stage_test.py
+++ b/azure-iot-device/tests/common/pipeline/pipeline_stage_test.py
@@ -145,7 +145,7 @@ def add_unknown_events_tests(cls, module, all_events, handled_events):
                     super(PreviousStage, self).__init__()
                     self.handle_pipeline_event = mocker.MagicMock()
 
-                def _run_op(self, op):
+                def _execute_op(self, op):
                     pass
 
             previous = PreviousStage()

--- a/azure-iot-device/tests/common/pipeline/test_operation_flow.py
+++ b/azure-iot-device/tests/common/pipeline/test_operation_flow.py
@@ -38,7 +38,7 @@ def apply_fake_pipeline_thread(fake_pipeline_thread):
 
 
 class MockPipelineStage(pipeline_stages_base.PipelineStage):
-    def _run_op(self, op):
+    def _execute_op(self, op):
         pass_op_to_next_stage(self, op)
 
 
@@ -73,8 +73,8 @@ class TestRunOpsSerialOneOpButNoFinallyOp(object):
     @pytest.mark.it("Runs the op")
     def test_runs_operation(self, mocker, stage, callback, op):
         run_ops_in_serial(stage, op, callback=callback)
-        assert stage.next._run_op.call_count == 1
-        assert stage.next._run_op.call_args == mocker.call(op)
+        assert stage.next._execute_op.call_count == 1
+        assert stage.next._execute_op.call_args == mocker.call(op)
 
     @pytest.mark.it("Calls the callback with no error if the op succeeds")
     def test_successful_operation(self, stage, callback, op):
@@ -112,18 +112,18 @@ class TestRunOpsSerialOneOpAndFinallyOp(object):
     @pytest.mark.it("Runs the first op")
     def test_runs_first_op(self, mocker, stage, callback, op, finally_op):
         run_ops_in_serial(stage, op, finally_op=finally_op, callback=callback)
-        assert stage.next._run_op.call_args_list[0] == mocker.call(op)
+        assert stage.next._execute_op.call_args_list[0] == mocker.call(op)
 
     @pytest.mark.it("Runs finally_op if the op succeeds")
     def test_runs_finally_op_on_success(self, mocker, stage, callback, op, finally_op):
         run_ops_in_serial(stage, op, finally_op=finally_op, callback=callback)
-        assert stage.next._run_op.call_args_list[1] == mocker.call(finally_op)
+        assert stage.next._execute_op.call_args_list[1] == mocker.call(finally_op)
 
     @pytest.mark.it("Runs finally_op if the op fails")
     def test_runs_finally_op_on_op_failure(self, mocker, stage, callback, op, finally_op):
         op.action = "fail"
         run_ops_in_serial(stage, op, finally_op=finally_op, callback=callback)
-        assert stage.next._run_op.call_args_list[1] == mocker.call(finally_op)
+        assert stage.next._execute_op.call_args_list[1] == mocker.call(finally_op)
 
     @pytest.mark.it(
         "Calls the callback with the finally_op error if op succeeds and finally_op fails"
@@ -191,8 +191,8 @@ class TestRunOpsSerialThreeOpsButNoFinallyOp(object):
     def test_runs_first_op(self, mocker, stage, op, op2, op3, callback):
         op.action = "pend"
         run_ops_in_serial(stage, op, op2, op3, callback=callback)
-        assert stage.next._run_op.call_count == 1
-        assert stage.next._run_op.call_args == mocker.call(op)
+        assert stage.next._execute_op.call_count == 1
+        assert stage.next._execute_op.call_args == mocker.call(op)
 
     @pytest.mark.it("Does not call the second or third op if the first op fails")
     def test_does_not_call_second_or_third_op_if_first_op_fails(
@@ -200,8 +200,8 @@ class TestRunOpsSerialThreeOpsButNoFinallyOp(object):
     ):
         op.action = "fail"
         run_ops_in_serial(stage, op, op2, op3, callback=callback)
-        assert stage.next._run_op.call_count == 1
-        assert stage.next._run_op.call_args == mocker.call(op)
+        assert stage.next._execute_op.call_count == 1
+        assert stage.next._execute_op.call_args == mocker.call(op)
 
     @pytest.mark.it("Calls the callback with the first op error if the first op fails")
     def test_calls_callback_when_first_op_fails(self, stage, op, op2, op3, callback):
@@ -233,19 +233,19 @@ class TestRunOpsSerialThreeOpsButNoFinallyOp(object):
         op.action = "pend"
         op2.action = "pend"
         run_ops_in_serial(stage, op, op2, op3, callback=callback)
-        assert stage.next._run_op.call_count == 1
-        assert stage.next._run_op.call_args == mocker.call(op)
+        assert stage.next._execute_op.call_count == 1
+        assert stage.next._execute_op.call_args == mocker.call(op)
         complete_op(stage.next, op)
-        assert stage.next._run_op.call_count == 2
-        assert stage.next._run_op.call_args_list[1] == mocker.call(op2)
+        assert stage.next._execute_op.call_count == 2
+        assert stage.next._execute_op.call_args_list[1] == mocker.call(op2)
 
     @pytest.mark.it("Does not run the third op after the second op fails")
     def test_does_not_run_third_op_if_second_op_fails(self, mocker, stage, op, op2, op3, callback):
         op2.action = "fail"
         run_ops_in_serial(stage, op, op2, op3, callback=callback)
-        assert stage.next._run_op.call_count == 2
-        assert stage.next._run_op.call_args_list[0] == mocker.call(op)
-        assert stage.next._run_op.call_args_list[1] == mocker.call(op2)
+        assert stage.next._execute_op.call_count == 2
+        assert stage.next._execute_op.call_args_list[0] == mocker.call(op)
+        assert stage.next._execute_op.call_args_list[1] == mocker.call(op2)
 
     @pytest.mark.it("Calls the callback with the second op error if the second op fails")
     def test_calls_callback_when_second_op_fails(self, stage, op, op2, op3, callback):
@@ -257,12 +257,12 @@ class TestRunOpsSerialThreeOpsButNoFinallyOp(object):
     def test_calls_third_op_after_second_op_succeeds(self, mocker, stage, op, op2, op3, callback):
         op2.action = "pend"
         run_ops_in_serial(stage, op, op2, op3, callback=callback)
-        assert stage.next._run_op.call_count == 2
-        assert stage.next._run_op.call_args_list[0] == mocker.call(op)
-        assert stage.next._run_op.call_args_list[1] == mocker.call(op2)
+        assert stage.next._execute_op.call_count == 2
+        assert stage.next._execute_op.call_args_list[0] == mocker.call(op)
+        assert stage.next._execute_op.call_args_list[1] == mocker.call(op2)
         complete_op(stage.next, op2)
-        assert stage.next._run_op.call_count == 3
-        assert stage.next._run_op.call_args_list[2] == mocker.call(op3)
+        assert stage.next._execute_op.call_count == 3
+        assert stage.next._execute_op.call_args_list[2] == mocker.call(op3)
 
     @pytest.mark.it("Calls the callback with success if the third op succeeds")
     def test_calls_callback_with_third_op_succeeds(self, stage, op, op2, op3, callback):
@@ -282,8 +282,8 @@ class TestRunOpsSerialThreeOpsAndFinallyOp(object):
     def test_runs_first_op(self, mocker, stage, op, op2, op3, finally_op, callback):
         op.action = "pend"
         run_ops_in_serial(stage, op, op2, op3, finally_op=finally_op, callback=callback)
-        assert stage.next._run_op.call_count == 1
-        assert stage.next._run_op.call_args == mocker.call(op)
+        assert stage.next._execute_op.call_count == 1
+        assert stage.next._execute_op.call_args == mocker.call(op)
 
     @pytest.mark.it(
         "Does not call the second or third op, bue does call the fanally_op if the first op fails"
@@ -293,9 +293,9 @@ class TestRunOpsSerialThreeOpsAndFinallyOp(object):
     ):
         op.action = "fail"
         run_ops_in_serial(stage, op, op2, op3, finally_op=finally_op, callback=callback)
-        assert stage.next._run_op.call_count == 2
-        assert stage.next._run_op.call_args_list[0] == mocker.call(op)
-        assert stage.next._run_op.call_args_list[1] == mocker.call(finally_op)
+        assert stage.next._execute_op.call_count == 2
+        assert stage.next._execute_op.call_args_list[0] == mocker.call(op)
+        assert stage.next._execute_op.call_args_list[1] == mocker.call(finally_op)
 
     @pytest.mark.it(
         "Calls the callback with the finally_op and the first_op error if the first op fails and finally_op succeeds"
@@ -342,10 +342,10 @@ class TestRunOpsSerialThreeOpsAndFinallyOp(object):
         op.action = "pend"
         op2.action = "pend"
         run_ops_in_serial(stage, op, op2, op3, callback=callback, finally_op=finally_op)
-        assert stage.next._run_op.call_count == 1
-        assert stage.next._run_op.call_args == mocker.call(op)
+        assert stage.next._execute_op.call_count == 1
+        assert stage.next._execute_op.call_args == mocker.call(op)
         complete_op(stage.next, op)
-        assert stage.next._run_op.call_args_list[1] == mocker.call(op2)
+        assert stage.next._execute_op.call_args_list[1] == mocker.call(op2)
 
     @pytest.mark.it("Does not run the third op but does run finally_op if the second op fails")
     def test_runs_finally_op_when_second_op_fails(
@@ -353,10 +353,10 @@ class TestRunOpsSerialThreeOpsAndFinallyOp(object):
     ):
         op2.action = "fail"
         run_ops_in_serial(stage, op, op2, op3, callback=callback, finally_op=finally_op)
-        assert stage.next._run_op.call_count == 3
-        assert stage.next._run_op.call_args_list[0] == mocker.call(op)
-        assert stage.next._run_op.call_args_list[1] == mocker.call(op2)
-        assert stage.next._run_op.call_args_list[2] == mocker.call(finally_op)
+        assert stage.next._execute_op.call_count == 3
+        assert stage.next._execute_op.call_args_list[0] == mocker.call(op)
+        assert stage.next._execute_op.call_args_list[1] == mocker.call(op2)
+        assert stage.next._execute_op.call_args_list[2] == mocker.call(finally_op)
 
     @pytest.mark.it(
         "Calls the callback with the finally_op and the  second_op error if the second op fails and finally_op succeeds"
@@ -386,13 +386,13 @@ class TestRunOpsSerialThreeOpsAndFinallyOp(object):
     ):
         op2.action = "pend"
         run_ops_in_serial(stage, op, op2, op3, callback=callback, finally_op=finally_op)
-        assert stage.next._run_op.call_count == 2
-        assert stage.next._run_op.call_args_list[0] == mocker.call(op)
-        assert stage.next._run_op.call_args_list[1] == mocker.call(op2)
+        assert stage.next._execute_op.call_count == 2
+        assert stage.next._execute_op.call_args_list[0] == mocker.call(op)
+        assert stage.next._execute_op.call_args_list[1] == mocker.call(op2)
         complete_op(stage.next, op2)
-        assert stage.next._run_op.call_count == 4
-        assert stage.next._run_op.call_args_list[2] == mocker.call(op3)
-        assert stage.next._run_op.call_args_list[3] == mocker.call(finally_op)
+        assert stage.next._execute_op.call_count == 4
+        assert stage.next._execute_op.call_args_list[2] == mocker.call(op3)
+        assert stage.next._execute_op.call_args_list[3] == mocker.call(finally_op)
 
     @pytest.mark.it("Runs finally_op if the third op fails")
     def test_runs_finally_op_if_third_op_fails(
@@ -400,16 +400,16 @@ class TestRunOpsSerialThreeOpsAndFinallyOp(object):
     ):
         op3.action = "fail"
         run_ops_in_serial(stage, op, op2, op3, callback=callback, finally_op=finally_op)
-        assert stage.next._run_op.call_count == 4
-        assert stage.next._run_op.call_args_list[3] == mocker.call(finally_op)
+        assert stage.next._execute_op.call_count == 4
+        assert stage.next._execute_op.call_args_list[3] == mocker.call(finally_op)
 
     @pytest.mark.it("Runs finally_op if the third op succeeds")
     def test_runs_finally_op_if_third_op_succeeds(
         self, mocker, stage, op, op2, op3, finally_op, callback
     ):
         run_ops_in_serial(stage, op, op2, op3, callback=callback, finally_op=finally_op)
-        assert stage.next._run_op.call_count == 4
-        assert stage.next._run_op.call_args_list[3] == mocker.call(finally_op)
+        assert stage.next._execute_op.call_count == 4
+        assert stage.next._execute_op.call_args_list[3] == mocker.call(finally_op)
 
     @pytest.mark.it(
         "Calls the callback with the finally_op if the third op succeeds and finally_op also succeeds"

--- a/azure-iot-device/tests/common/pipeline/test_pipeline_stages_base.py
+++ b/azure-iot-device/tests/common/pipeline/test_pipeline_stages_base.py
@@ -95,16 +95,16 @@ def _test_pipeline_root_runs_operation_in_pipeline_thread(
     # this test method gets added to, so it's a PipelineRootStage object
     assert threading.current_thread().name != "pipeline"
 
-    def mock_run_op(self, op):
-        print("mock_run_op called")
+    def mock_execute_op(self, op):
+        print("mock_execute_op called")
         assert threading.current_thread().name == "pipeline"
         op.callback(op)
 
-    mock_run_op = mocker.MagicMock(mock_run_op)
-    stage._run_op = mock_run_op
+    mock_execute_op = mocker.MagicMock(mock_execute_op)
+    stage._execute_op = mock_execute_op
 
     stage.run_op(op)
-    assert mock_run_op.call_count == 1
+    assert mock_execute_op.call_count == 1
 
 
 TestPipelineRootStagePipelineThreading.test_runs_callback_in_callback_thread = (
@@ -195,13 +195,13 @@ class TestCoordinateRequestAndResponseSendIotRequestRunOp(object):
         "Fails SendIotRequestAndWaitForResponseOperation if an Exception is raised in the SendIotRequestOperation op"
     )
     def test_new_op_raises_exception(self, stage, op, mocker):
-        stage.next._run_op = mocker.Mock(side_effect=Exception)
+        stage.next._execute_op = mocker.Mock(side_effect=Exception)
         stage.run_op(op)
         assert_callback_failed(op=op)
 
     @pytest.mark.it("Allows BaseExceptions rised on the SendIotRequestOperation op to propogate")
     def test_new_op_raises_base_exception(self, stage, op, mocker):
-        stage.next._run_op = mocker.Mock(side_effect=UnhandledException)
+        stage.next._execute_op = mocker.Mock(side_effect=UnhandledException)
         with pytest.raises(UnhandledException):
             stage.run_op(op)
         assert op.callback.call_count == 0
@@ -267,7 +267,7 @@ class TestCoordinateRequestAndResponseSendIotRequestHandleEvent(object):
         "Does nothing if an IotResponse with a request_id is received for an operation that returned failure"
     )
     def test_ignores_request_id_from_failure(self, stage, op, mocker, unhandled_error_handler):
-        stage.next._run_op = mocker.MagicMock(side_effect=Exception)
+        stage.next._execute_op = mocker.MagicMock(side_effect=Exception)
         stage.run_op(op)
 
         req = stage.next.run_op.call_args[0][0]

--- a/azure-iot-device/tests/iothub/pipeline/test_pipeline_stages_iothub.py
+++ b/azure-iot-device/tests/iothub/pipeline/test_pipeline_stages_iothub.py
@@ -141,19 +141,19 @@ class TestUseAuthProviderRunOpWithSetAuthProviderOperation(object):
 
     @pytest.mark.it("Runs SetIoTHubConnectionArgsOperation op on the next stage")
     def test_runs_set_auth_provider_args(self, mocker, stage, set_auth_provider):
-        stage.next._run_op = mocker.Mock()
+        stage.next._execute_op = mocker.Mock()
         stage.run_op(set_auth_provider)
-        assert stage.next._run_op.call_count == 1
-        set_args = stage.next._run_op.call_args[0][0]
+        assert stage.next._execute_op.call_count == 1
+        set_args = stage.next._execute_op.call_args[0][0]
         assert isinstance(set_args, pipeline_ops_iothub.SetIoTHubConnectionArgsOperation)
 
     @pytest.mark.it(
         "Sets the device_id, and hostname attributes on SetIoTHubConnectionArgsOperation based on the same-names auth_provider attributes"
     )
     def test_sets_required_attributes(self, mocker, stage, set_auth_provider):
-        stage.next._run_op = mocker.Mock()
+        stage.next._execute_op = mocker.Mock()
         stage.run_op(set_auth_provider)
-        set_args = stage.next._run_op.call_args[0][0]
+        set_args = stage.next._execute_op.call_args[0][0]
         assert set_args.device_id == fake_device_id
         assert set_args.hostname == fake_hostname
 
@@ -163,9 +163,9 @@ class TestUseAuthProviderRunOpWithSetAuthProviderOperation(object):
     def test_defaults_optional_attributes_to_none(
         self, mocker, stage, set_auth_provider, params_auth_provider_ops
     ):
-        stage.next._run_op = mocker.Mock()
+        stage.next._execute_op = mocker.Mock()
         stage.run_op(set_auth_provider)
-        set_args = stage.next._run_op.call_args[0][0]
+        set_args = stage.next._execute_op.call_args[0][0]
         assert set_args.gateway_hostname is None
         assert set_args.ca_cert is None
         if params_auth_provider_ops["name"] == "x509_auth_module":
@@ -179,9 +179,9 @@ class TestUseAuthProviderRunOpWithSetAuthProviderOperation(object):
     def test_sets_optional_attributes(
         self, mocker, stage, set_auth_provider_all_args, params_auth_provider_ops
     ):
-        stage.next._run_op = mocker.Mock()
+        stage.next._execute_op = mocker.Mock()
         stage.run_op(set_auth_provider_all_args)
-        set_args = stage.next._run_op.call_args[0][0]
+        set_args = stage.next._execute_op.call_args[0][0]
         assert set_args.module_id == fake_module_id
 
         if params_auth_provider_ops["name"] == "sas_token_auth":
@@ -194,7 +194,7 @@ class TestUseAuthProviderRunOpWithSetAuthProviderOperation(object):
     def test_set_auth_provider_raises_exception(
         self, mocker, stage, fake_exception, set_auth_provider
     ):
-        stage.next._run_op = mocker.Mock(side_effect=fake_exception)
+        stage.next._execute_op = mocker.Mock(side_effect=fake_exception)
         stage.run_op(set_auth_provider)
         assert_callback_failed(op=set_auth_provider, error=fake_exception)
 
@@ -204,7 +204,7 @@ class TestUseAuthProviderRunOpWithSetAuthProviderOperation(object):
     def test_set_auth_provider_raises_base_exception(
         self, mocker, stage, fake_base_exception, set_auth_provider
     ):
-        stage.next._run_op = mocker.Mock(side_effect=fake_base_exception)
+        stage.next._execute_op = mocker.Mock(side_effect=fake_base_exception)
         with pytest.raises(UnhandledException):
             stage.run_op(set_auth_provider)
 
@@ -222,7 +222,7 @@ class TestUseAuthProviderRunOpWithSetAuthProviderOperation(object):
 
         stage.run_op(set_auth_provider)
         assert spy_method.call_count == 1
-        set_connection_args_op = stage.next._run_op.call_args_list[0][0][0]
+        set_connection_args_op = stage.next._execute_op.call_args_list[0][0][0]
 
         if params_auth_provider_ops["name"] == "sas_token_auth":
             assert set_connection_args_op.sas_token == fake_sas_token

--- a/azure-iot-device/tests/iothub/pipeline/test_pipeline_stages_iothub_mqtt.py
+++ b/azure-iot-device/tests/iothub/pipeline/test_pipeline_stages_iothub_mqtt.py
@@ -234,8 +234,8 @@ class TestIoTHubMQTTConverterWithSetAuthProviderArgs(object):
     )
     def test_runs_set_connection_args(self, stage, set_connection_args):
         stage.run_op(set_connection_args)
-        assert stage.next._run_op.call_count == 1
-        new_op = stage.next._run_op.call_args[0][0]
+        assert stage.next._execute_op.call_count == 1
+        new_op = stage.next._execute_op.call_args[0][0]
         assert isinstance(new_op, pipeline_ops_mqtt.SetMQTTConnectionArgsOperation)
 
     @pytest.mark.it(
@@ -243,7 +243,7 @@ class TestIoTHubMQTTConverterWithSetAuthProviderArgs(object):
     )
     def test_sets_client_id_for_devices(self, stage, set_connection_args):
         stage.run_op(set_connection_args)
-        new_op = stage.next._run_op.call_args[0][0]
+        new_op = stage.next._execute_op.call_args[0][0]
         assert new_op.client_id == fake_device_id
 
     @pytest.mark.it(
@@ -251,7 +251,7 @@ class TestIoTHubMQTTConverterWithSetAuthProviderArgs(object):
     )
     def test_sets_client_id_for_modules(self, stage, set_connection_args_for_module):
         stage.run_op(set_connection_args_for_module)
-        new_op = stage.next._run_op.call_args[0][0]
+        new_op = stage.next._execute_op.call_args[0][0]
         assert new_op.client_id == "{}/{}".format(fake_device_id, fake_module_id)
 
     @pytest.mark.it(
@@ -259,7 +259,7 @@ class TestIoTHubMQTTConverterWithSetAuthProviderArgs(object):
     )
     def test_sets_hostname_if_no_gateway(self, stage, set_connection_args):
         stage.run_op(set_connection_args)
-        new_op = stage.next._run_op.call_args[0][0]
+        new_op = stage.next._execute_op.call_args[0][0]
         assert new_op.hostname == fake_hostname
 
     @pytest.mark.it(
@@ -268,7 +268,7 @@ class TestIoTHubMQTTConverterWithSetAuthProviderArgs(object):
     def test_sets_hostname_if_yes_gateway(self, stage, set_connection_args):
         set_connection_args.gateway_hostname = fake_gateway_hostname
         stage.run_op(set_connection_args)
-        new_op = stage.next._run_op.call_args[0][0]
+        new_op = stage.next._execute_op.call_args[0][0]
         assert new_op.hostname == fake_gateway_hostname
 
     @pytest.mark.it(
@@ -276,7 +276,7 @@ class TestIoTHubMQTTConverterWithSetAuthProviderArgs(object):
     )
     def test_sets_device_username_if_no_gateway(self, stage, set_connection_args):
         stage.run_op(set_connection_args)
-        new_op = stage.next._run_op.call_args[0][0]
+        new_op = stage.next._execute_op.call_args[0][0]
         assert new_op.username == "{}/{}/?api-version={}&DeviceClientType={}".format(
             fake_hostname, fake_device_id, pkg_constant.IOTHUB_API_VERSION, encoded_user_agent
         )
@@ -287,7 +287,7 @@ class TestIoTHubMQTTConverterWithSetAuthProviderArgs(object):
     def test_sets_device_username_if_yes_gateway(self, stage, set_connection_args):
         set_connection_args.gateway_hostname = fake_gateway_hostname
         stage.run_op(set_connection_args)
-        new_op = stage.next._run_op.call_args[0][0]
+        new_op = stage.next._execute_op.call_args[0][0]
         assert new_op.username == "{}/{}/?api-version={}&DeviceClientType={}".format(
             fake_hostname, fake_device_id, pkg_constant.IOTHUB_API_VERSION, encoded_user_agent
         )
@@ -297,7 +297,7 @@ class TestIoTHubMQTTConverterWithSetAuthProviderArgs(object):
     )
     def test_sets_module_username_if_no_gateway(self, stage, set_connection_args_for_module):
         stage.run_op(set_connection_args_for_module)
-        new_op = stage.next._run_op.call_args[0][0]
+        new_op = stage.next._execute_op.call_args[0][0]
         assert new_op.username == "{}/{}/{}/?api-version={}&DeviceClientType={}".format(
             fake_hostname,
             fake_device_id,
@@ -312,7 +312,7 @@ class TestIoTHubMQTTConverterWithSetAuthProviderArgs(object):
     def test_sets_module_username_if_yes_gateway(self, stage, set_connection_args_for_module):
         set_connection_args_for_module.gateway_hostname = fake_gateway_hostname
         stage.run_op(set_connection_args_for_module)
-        new_op = stage.next._run_op.call_args[0][0]
+        new_op = stage.next._execute_op.call_args[0][0]
         assert new_op.username == "{}/{}/{}/?api-version={}&DeviceClientType={}".format(
             fake_hostname,
             fake_device_id,
@@ -325,21 +325,21 @@ class TestIoTHubMQTTConverterWithSetAuthProviderArgs(object):
     def test_sets_ca_cert(self, stage, set_connection_args):
         set_connection_args.ca_cert = fake_ca_cert
         stage.run_op(set_connection_args)
-        new_op = stage.next._run_op.call_args[0][0]
+        new_op = stage.next._execute_op.call_args[0][0]
         assert new_op.ca_cert == fake_ca_cert
 
     @pytest.mark.it("Sets connection_args.client_cert to auth_provider.client_cert")
     def test_sets_client_cert(self, stage, set_connection_args):
         set_connection_args.client_cert = fake_client_cert
         stage.run_op(set_connection_args)
-        new_op = stage.next._run_op.call_args[0][0]
+        new_op = stage.next._execute_op.call_args[0][0]
         assert new_op.client_cert == fake_client_cert
 
     @pytest.mark.it("Sets connection_args.sas_token to auth_provider.sas_token.")
     def test_sets_sas_token(self, stage, set_connection_args):
         set_connection_args.sas_token = fake_sas_token
         stage.run_op(set_connection_args)
-        new_op = stage.next._run_op.call_args[0][0]
+        new_op = stage.next._execute_op.call_args[0][0]
         assert new_op.sas_token == fake_sas_token
 
     @pytest.mark.it(
@@ -348,7 +348,7 @@ class TestIoTHubMQTTConverterWithSetAuthProviderArgs(object):
     def test_set_connection_args_raises_exception(
         self, stage, mocker, fake_exception, set_connection_args
     ):
-        stage.next._run_op = mocker.Mock(side_effect=fake_exception)
+        stage.next._execute_op = mocker.Mock(side_effect=fake_exception)
         stage.run_op(set_connection_args)
         assert_callback_failed(op=set_connection_args, error=fake_exception)
 
@@ -358,7 +358,7 @@ class TestIoTHubMQTTConverterWithSetAuthProviderArgs(object):
     def test_set_connection_args_raises_base_exception(
         self, stage, mocker, fake_base_exception, set_connection_args
     ):
-        stage.next._run_op = mocker.Mock(side_effect=fake_base_exception)
+        stage.next._execute_op = mocker.Mock(side_effect=fake_base_exception)
         with pytest.raises(UnhandledException):
             stage.run_op(set_connection_args)
 
@@ -415,14 +415,14 @@ class TestIoTHubMQTTConverterBasicOperations(object):
     @pytest.mark.it("Runs an operation on the next stage")
     def test_runs_publish(self, params, stage, stages_configured_for_both, op):
         stage.run_op(op)
-        new_op = stage.next._run_op.call_args[0][0]
+        new_op = stage.next._execute_op.call_args[0][0]
         assert isinstance(new_op, params["new_op_class"])
 
     @pytest.mark.it("Calls the original op callback with error if the new_op raises an exception")
     def test_operation_raises_exception(
         self, params, mocker, stage, stages_configured_for_both, op, fake_exception
     ):
-        stage.next._run_op = mocker.Mock(side_effect=fake_exception)
+        stage.next._execute_op = mocker.Mock(side_effect=fake_exception)
         stage.run_op(op)
         assert_callback_failed(op=op, error=fake_exception)
 
@@ -430,7 +430,7 @@ class TestIoTHubMQTTConverterBasicOperations(object):
     def test_operation_raises_base_exception(
         self, params, mocker, stage, stages_configured_for_both, op, fake_base_exception
     ):
-        stage.next._run_op = mocker.Mock(side_effect=fake_base_exception)
+        stage.next._execute_op = mocker.Mock(side_effect=fake_base_exception)
         with pytest.raises(UnhandledException):
             stage.run_op(op)
 
@@ -651,7 +651,7 @@ class TestIoTHubMQTTConverterForPublishOps(object):
         elif params["stage_type"] == "module" and not stage.module_id:
             pytest.skip()
         stage.run_op(op)
-        new_op = stage.next._run_op.call_args[0][0]
+        new_op = stage.next._execute_op.call_args[0][0]
         if "multiple user properties" in params["name"]:
             assert new_op.topic == params["topic1"] or new_op.topic == params["topic2"]
         else:
@@ -660,7 +660,7 @@ class TestIoTHubMQTTConverterForPublishOps(object):
     @pytest.mark.it("Sends the body in the payload of the MQTT publish operation")
     def test_sends_correct_body(self, stage, stages_configured_for_both, params, op):
         stage.run_op(op)
-        new_op = stage.next._run_op.call_args[0][0]
+        new_op = stage.next._execute_op.call_args[0][0]
         assert new_op.payload == params["publish_payload"]
 
 
@@ -715,10 +715,10 @@ class TestIoTHubMQTTConverterWithEnableFeature(object):
             pytest.skip()
         elif topic_parameters["stage_type"] == "module" and not stage.module_id:
             pytest.skip()
-        stage.next._run_op = mocker.Mock()
+        stage.next._execute_op = mocker.Mock()
         op = op_parameters["op_class"](feature_name=topic_parameters["feature_name"])
         stage.run_op(op)
-        new_op = stage.next._run_op.call_args[0][0]
+        new_op = stage.next._execute_op.call_args[0][0]
         assert isinstance(new_op, op_parameters["new_op"])
         assert new_op.topic == topic_parameters["topic"]
 

--- a/azure-iot-device/tests/provisioning/pipeline/test_pipeline_stages_provisioning.py
+++ b/azure-iot-device/tests/provisioning/pipeline/test_pipeline_stages_provisioning.py
@@ -127,10 +127,10 @@ def set_security_client(callback, params_security_ops):
 class TestUseSymmetricKeyOrX509SecurityClientRunOpWithSetSecurityClient(object):
     @pytest.mark.it("runs SetProvisioningClientConnectionArgsOperation op on the next stage")
     def test_runs_set_security_client_args(self, mocker, security_stage, set_security_client):
-        security_stage.next._run_op = mocker.Mock()
+        security_stage.next._execute_op = mocker.Mock()
         security_stage.run_op(set_security_client)
-        assert security_stage.next._run_op.call_count == 1
-        set_args = security_stage.next._run_op.call_args[0][0]
+        assert security_stage.next._execute_op.call_count == 1
+        set_args = security_stage.next._execute_op.call_args[0][0]
         assert isinstance(
             set_args, pipeline_ops_provisioning.SetProvisioningClientConnectionArgsOperation
         )
@@ -142,7 +142,7 @@ class TestUseSymmetricKeyOrX509SecurityClientRunOpWithSetSecurityClient(object):
     def test_set_security_client_raises_exception(
         self, mocker, security_stage, fake_exception, set_security_client
     ):
-        security_stage.next._run_op = mocker.Mock(side_effect=fake_exception)
+        security_stage.next._execute_op = mocker.Mock(side_effect=fake_exception)
         security_stage.run_op(set_security_client)
         assert_callback_failed(op=set_security_client, error=fake_exception)
 
@@ -152,7 +152,7 @@ class TestUseSymmetricKeyOrX509SecurityClientRunOpWithSetSecurityClient(object):
     def test_set_security_client_raises_base_exception(
         self, mocker, security_stage, fake_base_exception, set_security_client
     ):
-        security_stage.next._run_op = mocker.Mock(side_effect=fake_base_exception)
+        security_stage.next._execute_op = mocker.Mock(side_effect=fake_base_exception)
         with pytest.raises(UnhandledException):
             security_stage.run_op(set_security_client)
 
@@ -173,7 +173,7 @@ class TestUseSymmetricKeyOrX509SecurityClientRunOpWithSetSecurityClient(object):
         security_stage.run_op(set_security_client)
         assert spy_method.call_count == 1
 
-        set_connection_args_op = security_stage.next._run_op.call_args[0][0]
+        set_connection_args_op = security_stage.next._execute_op.call_args[0][0]
 
         if (
             params_security_ops["current_op_class"].__name__

--- a/azure-iot-device/tests/provisioning/pipeline/test_pipeline_stages_provisioning_mqtt.py
+++ b/azure-iot-device/tests/provisioning/pipeline/test_pipeline_stages_provisioning_mqtt.py
@@ -121,8 +121,8 @@ class TestProvisioningMQTTConverterWithSetProvisioningClientConnectionArgsOperat
     )
     def test_runs_set_connection_args(self, mock_stage, set_security_client_args):
         mock_stage.run_op(set_security_client_args)
-        assert mock_stage.next._run_op.call_count == 1
-        new_op = mock_stage.next._run_op.call_args[0][0]
+        assert mock_stage.next._execute_op.call_count == 1
+        new_op = mock_stage.next._execute_op.call_args[0][0]
         assert isinstance(new_op, pipeline_ops_mqtt.SetMQTTConnectionArgsOperation)
 
     @pytest.mark.it(
@@ -130,7 +130,7 @@ class TestProvisioningMQTTConverterWithSetProvisioningClientConnectionArgsOperat
     )
     def test_sets_client_id(self, mock_stage, set_security_client_args):
         mock_stage.run_op(set_security_client_args)
-        new_op = mock_stage.next._run_op.call_args[0][0]
+        new_op = mock_stage.next._execute_op.call_args[0][0]
         assert new_op.client_id == fake_registration_id
 
     @pytest.mark.it(
@@ -138,7 +138,7 @@ class TestProvisioningMQTTConverterWithSetProvisioningClientConnectionArgsOperat
     )
     def test_sets_hostname(self, mock_stage, set_security_client_args):
         mock_stage.run_op(set_security_client_args)
-        new_op = mock_stage.next._run_op.call_args[0][0]
+        new_op = mock_stage.next._execute_op.call_args[0][0]
         assert new_op.hostname == fake_provisioning_host
 
     @pytest.mark.it(
@@ -146,7 +146,7 @@ class TestProvisioningMQTTConverterWithSetProvisioningClientConnectionArgsOperat
     )
     def test_sets_client_cert(self, mock_stage, set_security_client_args):
         mock_stage.run_op(set_security_client_args)
-        new_op = mock_stage.next._run_op.call_args[0][0]
+        new_op = mock_stage.next._execute_op.call_args[0][0]
         assert new_op.client_cert == fake_client_cert
 
     @pytest.mark.it(
@@ -154,7 +154,7 @@ class TestProvisioningMQTTConverterWithSetProvisioningClientConnectionArgsOperat
     )
     def test_sets_sas_token(self, mock_stage, set_security_client_args):
         mock_stage.run_op(set_security_client_args)
-        new_op = mock_stage.next._run_op.call_args[0][0]
+        new_op = mock_stage.next._execute_op.call_args[0][0]
         assert new_op.sas_token == fake_sas_token
 
     @pytest.mark.it(
@@ -162,7 +162,7 @@ class TestProvisioningMQTTConverterWithSetProvisioningClientConnectionArgsOperat
     )
     def test_sets_username(self, mock_stage, set_security_client_args):
         mock_stage.run_op(set_security_client_args)
-        new_op = mock_stage.next._run_op.call_args[0][0]
+        new_op = mock_stage.next._execute_op.call_args[0][0]
         assert (
             new_op.username
             == "{id_scope}/registrations/{registration_id}/api-version={api_version}&ClientVersion={client_version}".format(
@@ -179,7 +179,7 @@ class TestProvisioningMQTTConverterWithSetProvisioningClientConnectionArgsOperat
     def test_set_connection_args_raises_exception(
         self, mock_stage, mocker, some_exception, set_security_client_args
     ):
-        mock_stage.next._run_op = mocker.Mock(side_effect=some_exception)
+        mock_stage.next._execute_op = mocker.Mock(side_effect=some_exception)
         mock_stage.run_op(set_security_client_args)
         assert_callback_failed(op=set_security_client_args, error=some_exception)
 
@@ -189,7 +189,7 @@ class TestProvisioningMQTTConverterWithSetProvisioningClientConnectionArgsOperat
     def test_set_connection_args_raises_base_exception(
         self, mock_stage, mocker, fake_base_exception, set_security_client_args
     ):
-        mock_stage.next._run_op = mocker.Mock(side_effect=fake_base_exception)
+        mock_stage.next._execute_op = mocker.Mock(side_effect=fake_base_exception)
         with pytest.raises(UnhandledException):
             mock_stage.run_op(set_security_client_args)
 
@@ -248,14 +248,14 @@ class TestProvisioningMQTTConverterBasicOperations(object):
     @pytest.mark.it("Runs an operation on the next stage")
     def test_runs_publish(self, params, mock_stage, stages_configured, op):
         mock_stage.run_op(op)
-        new_op = mock_stage.next._run_op.call_args[0][0]
+        new_op = mock_stage.next._execute_op.call_args[0][0]
         assert isinstance(new_op, params["new_op_class"])
 
     @pytest.mark.it("Calls the original op callback with error if the new_op raises an Exception")
     def test_new_op_raises_exception(
         self, params, mocker, mock_stage, stages_configured, op, some_exception
     ):
-        mock_stage.next._run_op = mocker.Mock(side_effect=some_exception)
+        mock_stage.next._execute_op = mocker.Mock(side_effect=some_exception)
         mock_stage.run_op(op)
         assert_callback_failed(op=op, error=some_exception)
 
@@ -263,7 +263,7 @@ class TestProvisioningMQTTConverterBasicOperations(object):
     def test_new_op_raises_base_exception(
         self, params, mocker, mock_stage, stages_configured, op, fake_base_exception
     ):
-        mock_stage.next._run_op = mocker.Mock(side_effect=fake_base_exception)
+        mock_stage.next._execute_op = mocker.Mock(side_effect=fake_base_exception)
         with pytest.raises(UnhandledException):
             mock_stage.run_op(op)
 
@@ -305,13 +305,13 @@ class TestProvisioningMQTTConverterForPublishOps(object):
     @pytest.mark.it("Uses correct registration topic string when publishing")
     def test_uses_topic_for(self, mock_stage, stages_configured, params, op):
         mock_stage.run_op(op)
-        new_op = mock_stage.next._run_op.call_args[0][0]
+        new_op = mock_stage.next._execute_op.call_args[0][0]
         assert new_op.topic == params["topic"]
 
     @pytest.mark.it("Sends correct payload when publishing")
     def test_sends_correct_body(self, mock_stage, stages_configured, params, op):
         mock_stage.run_op(op)
-        new_op = mock_stage.next._run_op.call_args[0][0]
+        new_op = mock_stage.next._execute_op.call_args[0][0]
         assert new_op.payload == params["publish_payload"]
 
 
@@ -339,11 +339,11 @@ class TestProvisioningMQTTConverterWithEnable(object):
         self, mocker, mock_stage, stages_configured, op_parameters
     ):
         topic = "$dps/registrations/res/#"
-        mock_stage.next._run_op = mocker.Mock()
+        mock_stage.next._execute_op = mocker.Mock()
 
         op = op_parameters["op_class"](feature_name=None)
         mock_stage.run_op(op)
-        new_op = mock_stage.next._run_op.call_args[0][0]
+        new_op = mock_stage.next._execute_op.call_args[0][0]
         assert isinstance(new_op, op_parameters["new_op"])
         assert new_op.topic == topic
 


### PR DESCRIPTION
* Renamed `PipelineStage._run_op()` to `PipelineStage._execute_op()` to distinguish as a unit from the wrapping `PipelineStage.run_op()`