### PR TITLE
[REFACTOR] Consistent Fail Op Pattern

### DIFF
--- a/azure-iot-device/azure/iot/device/common/pipeline/operation_flow.py
+++ b/azure-iot-device/azure/iot/device/common/pipeline/operation_flow.py
@@ -100,6 +100,11 @@ def complete_op(stage, op, error=None):
     (such as a try/except wrapper) which are strongly advised.
     """
     if error:
+        if op.error:
+            # This shouldn't happen. If it does, something is wrong.
+            # You should EITHER set the error on the op, and not pass the error as param,
+            # OR only pass the error as a param.
+            logger.warning("Ovewriting {} error with {} error".format(op.error, error))
         op.error = error
 
     logger.info(

--- a/azure-iot-device/azure/iot/device/common/pipeline/operation_flow.py
+++ b/azure-iot-device/azure/iot/device/common/pipeline/operation_flow.py
@@ -92,13 +92,16 @@ def pass_op_to_next_stage(stage, op):
 
 
 @pipeline_thread.runs_on_pipeline_thread
-def complete_op(stage, op):
+def complete_op(stage, op, error=None):
     """
     Helper function to complete an operation by calling its callback function thus
     returning the result of the operation back up the pipeline.  This is perferred to
     calling the operation's callback directly as it provides several layers of protection
     (such as a try/except wrapper) which are strongly advised.
     """
+    if error:
+        op.error = error
+
     logger.info(
         "{}({}): completing {} error".format(stage.name, op.name, "with" if op.error else "without")
     )

--- a/azure-iot-device/azure/iot/device/common/pipeline/pipeline_stages_base.py
+++ b/azure-iot-device/azure/iot/device/common/pipeline/pipeline_stages_base.py
@@ -96,6 +96,8 @@ class PipelineStage(object):
         try:
             self._execute_op(op)
         except Exception as e:
+            # This path is ONLY for unexpected errors. Expected errors should cause a fail completion
+            # within ._execute_op()
             logger.error(msg="Unexpected error in {}._execute_op() call".format(self), exc_info=e)
             operation_flow.complete_op(stage=self, op=op, error=e)
 

--- a/azure-iot-device/tests/common/pipeline/test_operation_flow.py
+++ b/azure-iot-device/tests/common/pipeline/test_operation_flow.py
@@ -116,7 +116,7 @@ class TestCompleteOp(object):
     @pytest.mark.it("Sets the error in an op, if provided")
     def test_sets_error(self, stage, op, callback, fake_exception):
         op.callback = callback
-        complete_op(stage, op, fake_exception)
+        complete_op(stage=stage, op=op, error=fake_exception)
 
         assert_callback_failed(op=op, error=fake_exception)
         assert op.error is fake_exception
@@ -131,7 +131,7 @@ class TestCompleteOp(object):
         op.error = ValueError()
         assert op.error is not fake_exception
 
-        complete_op(stage, op, fake_exception)
+        complete_op(stage=stage, op=op, error=fake_exception)
         assert_callback_failed(op=op, error=fake_exception)
         assert op.error is fake_exception
 


### PR DESCRIPTION
* Added optional `error` parameter to `operation_flow.complete_op()` that sets error
* Changed most fail completions in stages to use this new parameter instead of a manual error set
* Some stages would have required extensive refactoring, so were not changed. 
* Removed ALL instances of raising an error in `PipelineStage._execute_op()` in order to be caught and sent into the wrapping `PipelineStage.run_op()` to do an op completion with error. This path is now ONLY for unexpected exceptions.