### PR TITLE
move ensure connection down and add separate stage to serialize conne…

### DIFF
--- a/azure-iot-device/azure/iot/device/common/pipeline/pipeline_ops_base.py
+++ b/azure-iot-device/azure/iot/device/common/pipeline/pipeline_ops_base.py
@@ -113,7 +113,6 @@ class EnableFeatureOperation(PipelineOperation):
         """
         super(EnableFeatureOperation, self).__init__(callback=callback)
         self.feature_name = feature_name
-        self.needs_connection = True
 
 
 class DisableFeatureOperation(PipelineOperation):
@@ -142,7 +141,6 @@ class DisableFeatureOperation(PipelineOperation):
         """
         super(DisableFeatureOperation, self).__init__(callback=callback)
         self.feature_name = feature_name
-        self.needs_connection = True
 
 
 class SendIotRequestAndWaitForResponseOperation(PipelineOperation):
@@ -188,7 +186,6 @@ class SendIotRequestAndWaitForResponseOperation(PipelineOperation):
         self.request_body = request_body
         self.status_code = None
         self.response_body = None
-        self.needs_connection = True
 
 
 class SendIotRequestOperation(PipelineOperation):
@@ -225,4 +222,3 @@ class SendIotRequestOperation(PipelineOperation):
         self.request_type = request_type
         self.request_body = request_body
         self.request_id = request_id
-        self.needs_connection = True

--- a/azure-iot-device/azure/iot/device/common/pipeline/pipeline_ops_mqtt.py
+++ b/azure-iot-device/azure/iot/device/common/pipeline/pipeline_ops_mqtt.py
@@ -67,6 +67,7 @@ class MQTTPublishOperation(PipelineOperation):
         super(MQTTPublishOperation, self).__init__(callback=callback)
         self.topic = topic
         self.payload = payload
+        self.needs_connection = True
 
 
 class MQTTSubscribeOperation(PipelineOperation):
@@ -87,6 +88,7 @@ class MQTTSubscribeOperation(PipelineOperation):
         """
         super(MQTTSubscribeOperation, self).__init__(callback=callback)
         self.topic = topic
+        self.needs_connection = True
 
 
 class MQTTUnsubscribeOperation(PipelineOperation):
@@ -107,3 +109,4 @@ class MQTTUnsubscribeOperation(PipelineOperation):
         """
         super(MQTTUnsubscribeOperation, self).__init__(callback=callback)
         self.topic = topic
+        self.needs_connection = True

--- a/azure-iot-device/azure/iot/device/common/pipeline/pipeline_stages_mqtt.py
+++ b/azure-iot-device/azure/iot/device/common/pipeline/pipeline_stages_mqtt.py
@@ -75,7 +75,6 @@ class MQTTTransportStage(PipelineStage):
             self.transport.on_mqtt_message_received_handler = self._on_mqtt_message_received
             self._active_connect_op = None
             self._active_disconnect_op = None
-            self.pipeline_root.transport = self.transport
             operation_flow.complete_op(self, op)
 
         elif isinstance(op, pipeline_ops_base.ConnectOperation):

--- a/azure-iot-device/azure/iot/device/iothub/pipeline/iothub_pipeline.py
+++ b/azure-iot-device/azure/iot/device/iothub/pipeline/iothub_pipeline.py
@@ -50,8 +50,9 @@ class IoTHubPipeline(object):
             .append_stage(pipeline_stages_iothub.UseAuthProviderStage())
             .append_stage(pipeline_stages_iothub.HandleTwinOperationsStage())
             .append_stage(pipeline_stages_base.CoordinateRequestAndResponseStage())
-            .append_stage(pipeline_stages_base.EnsureConnectionStage())
             .append_stage(pipeline_stages_iothub_mqtt.IoTHubMQTTConverterStage())
+            .append_stage(pipeline_stages_base.EnsureConnectionStage())
+            .append_stage(pipeline_stages_base.SerializeConnectOpsStage())
             .append_stage(pipeline_stages_mqtt.MQTTTransportStage())
         )
 

--- a/azure-iot-device/azure/iot/device/iothub/pipeline/iothub_pipeline.py
+++ b/azure-iot-device/azure/iot/device/iothub/pipeline/iothub_pipeline.py
@@ -56,7 +56,7 @@ class IoTHubPipeline(object):
             .append_stage(pipeline_stages_mqtt.MQTTTransportStage())
         )
 
-        def _handle_pipeline_event(event):
+        def _on_pipeline_event(event):
             if isinstance(event, pipeline_events_iothub.C2DMessageEvent):
                 if self.on_c2d_message_received:
                     self.on_c2d_message_received(event.message)
@@ -84,17 +84,17 @@ class IoTHubPipeline(object):
             else:
                 logger.warning("Dropping unknown pipeline event {}".format(event.name))
 
-        def _handle_connected():
+        def _on_connected():
             if self.on_connected:
                 self.on_connected()
 
-        def _handle_disconnected():
+        def _on_disconnected():
             if self.on_disconnected:
                 self.on_disconnected()
 
-        self._pipeline.on_pipeline_event = _handle_pipeline_event
-        self._pipeline.on_connected = _handle_connected
-        self._pipeline.on_disconnected = _handle_disconnected
+        self._pipeline.on_pipeline_event_handler = _on_pipeline_event
+        self._pipeline.on_connected_handler = _on_connected
+        self._pipeline.on_disconnected_handler = _on_disconnected
 
         def remove_this_code(call):
             if call.error:

--- a/azure-iot-device/azure/iot/device/iothub/pipeline/pipeline_ops_iothub.py
+++ b/azure-iot-device/azure/iot/device/iothub/pipeline/pipeline_ops_iothub.py
@@ -122,7 +122,6 @@ class SendD2CMessageOperation(PipelineOperation):
         """
         super(SendD2CMessageOperation, self).__init__(callback=callback)
         self.message = message
-        self.needs_connection = True
 
 
 class SendOutputEventOperation(PipelineOperation):
@@ -144,7 +143,6 @@ class SendOutputEventOperation(PipelineOperation):
         """
         super(SendOutputEventOperation, self).__init__(callback=callback)
         self.message = message
-        self.needs_connection = True
 
 
 class SendMethodResponseOperation(PipelineOperation):
@@ -167,7 +165,6 @@ class SendMethodResponseOperation(PipelineOperation):
         """
         super(SendMethodResponseOperation, self).__init__(callback=callback)
         self.method_response = method_response
-        self.needs_connection = True
 
 
 class GetTwinOperation(PipelineOperation):
@@ -185,7 +182,6 @@ class GetTwinOperation(PipelineOperation):
         """
         super(GetTwinOperation, self).__init__(callback=callback)
         self.twin = None
-        self.needs_connection = True
 
 
 class PatchTwinReportedPropertiesOperation(PipelineOperation):
@@ -203,4 +199,3 @@ class PatchTwinReportedPropertiesOperation(PipelineOperation):
         """
         super(PatchTwinReportedPropertiesOperation, self).__init__(callback=callback)
         self.patch = patch
-        self.needs_connection = True

--- a/azure-iot-device/azure/iot/device/provisioning/pipeline/pipeline_ops_provisioning.py
+++ b/azure-iot-device/azure/iot/device/provisioning/pipeline/pipeline_ops_provisioning.py
@@ -112,7 +112,6 @@ class SendRegistrationRequestOperation(PipelineOperation):
         super(SendRegistrationRequestOperation, self).__init__(callback=callback)
         self.request_id = request_id
         self.request_payload = request_payload
-        self.needs_connection = True
 
 
 class SendQueryRequestOperation(PipelineOperation):
@@ -137,4 +136,3 @@ class SendQueryRequestOperation(PipelineOperation):
         self.request_id = request_id
         self.operation_id = operation_id
         self.request_payload = request_payload
-        self.needs_connection = True

--- a/azure-iot-device/azure/iot/device/provisioning/pipeline/provisioning_pipeline.py
+++ b/azure-iot-device/azure/iot/device/provisioning/pipeline/provisioning_pipeline.py
@@ -39,7 +39,7 @@ class ProvisioningPipeline(object):
             .append_stage(pipeline_stages_mqtt.MQTTTransportStage())
         )
 
-        def _handle_pipeline_event(event):
+        def _on_pipeline_event(event):
             if isinstance(event, pipeline_events_provisioning.RegistrationResponseEvent):
                 if self.on_message_received:
                     self.on_message_received(
@@ -54,17 +54,17 @@ class ProvisioningPipeline(object):
             else:
                 logger.warning("Dropping unknown pipeline event {}".format(event.name))
 
-        def _handle_connected():
+        def _on_connected():
             if self.on_connected:
                 self.on_connected("connected")
 
-        def _handle_disconnected():
+        def _on_disconnected():
             if self.on_disconnected:
                 self.on_disconnected("disconnected")
 
-        self._pipeline.on_pipeline_event = _handle_pipeline_event
-        self._pipeline.on_connected = _handle_connected
-        self._pipeline.on_disconnected = _handle_disconnected
+        self._pipeline.on_pipeline_event_handler = _on_pipeline_event
+        self._pipeline.on_connected_handler = _on_connected
+        self._pipeline.on_disconnected_handler = _on_disconnected
 
         def remove_this_code(call):
             if call.error:

--- a/azure-iot-device/azure/iot/device/provisioning/pipeline/provisioning_pipeline.py
+++ b/azure-iot-device/azure/iot/device/provisioning/pipeline/provisioning_pipeline.py
@@ -33,8 +33,9 @@ class ProvisioningPipeline(object):
         self._pipeline = (
             pipeline_stages_base.PipelineRootStage()
             .append_stage(pipeline_stages_provisioning.UseSecurityClientStage())
-            .append_stage(pipeline_stages_base.EnsureConnectionStage())
             .append_stage(pipeline_stages_provisioning_mqtt.ProvisioningMQTTConverterStage())
+            .append_stage(pipeline_stages_base.EnsureConnectionStage())
+            .append_stage(pipeline_stages_base.SerializeConnectOpsStage())
             .append_stage(pipeline_stages_mqtt.MQTTTransportStage())
         )
 

--- a/azure-iot-device/tests/common/pipeline/helpers.py
+++ b/azure-iot-device/tests/common/pipeline/helpers.py
@@ -84,10 +84,13 @@ def make_mock_stage(mocker, stage_to_make):
     mocker.spy(next_stage, "run_op")
 
     first_stage.next = next_stage
+    # TODO: this is sloppy.  we should have a real root here for testing.
     first_stage.pipeline_root = first_stage
 
     next_stage.previous = first_stage
     next_stage.pipeline_root = first_stage
+
+    first_stage.pipeline_root.connected = False
 
     return first_stage
 

--- a/azure-iot-device/tests/common/pipeline/pipeline_data_object_test.py
+++ b/azure-iot-device/tests/common/pipeline/pipeline_data_object_test.py
@@ -129,7 +129,10 @@ def add_instantiation_test(
         def test_defaults(self):
             instance = cls(*args)
             for key in all_defaults:
-                assert getattr(instance, key) == all_defaults[key]
+                if all_defaults[key].__class__ == type:
+                    assert isinstance(getattr(instance, key), all_defaults[key])
+                else:
+                    assert getattr(instance, key) == all_defaults[key]
 
     # Adding this object to the namespace of the module that was passed in (using a name that starts with "Test")
     # will cause pytest to pick it up.

--- a/azure-iot-device/tests/common/pipeline/pipeline_data_object_test.py
+++ b/azure-iot-device/tests/common/pipeline/pipeline_data_object_test.py
@@ -4,6 +4,7 @@
 # license information.
 # --------------------------------------------------------------------------
 import pytest
+import inspect
 
 fake_count = 0
 
@@ -129,7 +130,7 @@ def add_instantiation_test(
         def test_defaults(self):
             instance = cls(*args)
             for key in all_defaults:
-                if all_defaults[key].__class__ == type:
+                if inspect.isclass(all_defaults[key]):
                     assert isinstance(getattr(instance, key), all_defaults[key])
                 else:
                     assert getattr(instance, key) == all_defaults[key]

--- a/azure-iot-device/tests/common/pipeline/pipeline_stage_test.py
+++ b/azure-iot-device/tests/common/pipeline/pipeline_stage_test.py
@@ -33,6 +33,7 @@ def add_base_pipeline_stage_tests(
     handled_events,
     methods_that_enter_pipeline_thread=[],
     methods_that_can_run_in_any_thread=[],
+    extra_initializer_defaults={},
 ):
     """
     Add all of the "basic" tests for validating a pipeline stage.  This includes tests for
@@ -43,6 +44,7 @@ def add_base_pipeline_stage_tests(
         cls=cls,
         module=module,
         defaults={"name": cls.__name__, "next": None, "previous": None, "pipeline_root": None},
+        extra_defaults=extra_initializer_defaults,
     )
     add_unknown_ops_tests(cls=cls, module=module, all_ops=all_ops, handled_ops=handled_ops)
     add_unknown_events_tests(

--- a/azure-iot-device/tests/common/pipeline/test_pipeline_ops_base.py
+++ b/azure-iot-device/tests/common/pipeline/test_pipeline_ops_base.py
@@ -44,21 +44,18 @@ pipeline_data_object_test.add_operation_test(
     module=this_module,
     positional_arguments=["feature_name"],
     keyword_arguments={"callback": None},
-    extra_defaults={"needs_connection": True},
 )
 pipeline_data_object_test.add_operation_test(
     cls=pipeline_ops_base.DisableFeatureOperation,
     module=this_module,
     positional_arguments=["feature_name"],
     keyword_arguments={"callback": None},
-    extra_defaults={"needs_connection": True},
 )
 pipeline_data_object_test.add_operation_test(
     cls=pipeline_ops_base.SendIotRequestAndWaitForResponseOperation,
     module=this_module,
     positional_arguments=["request_type", "method", "resource_location", "request_body"],
     keyword_arguments={"callback": None},
-    extra_defaults={"needs_connection": True},
 )
 pipeline_data_object_test.add_operation_test(
     cls=pipeline_ops_base.SendIotRequestOperation,
@@ -71,5 +68,4 @@ pipeline_data_object_test.add_operation_test(
         "request_id",
     ],
     keyword_arguments={"callback": None},
-    extra_defaults={"needs_connection": True},
 )

--- a/azure-iot-device/tests/common/pipeline/test_pipeline_ops_mqtt.py
+++ b/azure-iot-device/tests/common/pipeline/test_pipeline_ops_mqtt.py
@@ -22,16 +22,19 @@ pipeline_data_object_test.add_operation_test(
     module=this_module,
     positional_arguments=["topic", "payload"],
     keyword_arguments={"callback": None},
+    extra_defaults={"needs_connection": True},
 )
 pipeline_data_object_test.add_operation_test(
     cls=pipeline_ops_mqtt.MQTTSubscribeOperation,
     module=this_module,
     positional_arguments=["topic"],
     keyword_arguments={"callback": None},
+    extra_defaults={"needs_connection": True},
 )
 pipeline_data_object_test.add_operation_test(
     cls=pipeline_ops_mqtt.MQTTUnsubscribeOperation,
     module=this_module,
     positional_arguments=["topic"],
     keyword_arguments={"callback": None},
+    extra_defaults={"needs_connection": True},
 )

--- a/azure-iot-device/tests/common/pipeline/test_pipeline_stages_base.py
+++ b/azure-iot-device/tests/common/pipeline/test_pipeline_stages_base.py
@@ -10,6 +10,7 @@ import threading
 from azure.iot.device.common.pipeline import (
     pipeline_stages_base,
     pipeline_ops_base,
+    pipeline_ops_mqtt,
     pipeline_events_base,
     operation_flow,
 )
@@ -35,23 +36,6 @@ logging.basicConfig(level=logging.INFO)
 @pytest.fixture(autouse=True)
 def apply_fake_pipeline_thread(fake_pipeline_thread):
     pass
-
-
-pipeline_stage_test.add_base_pipeline_stage_tests(
-    cls=pipeline_stages_base.EnsureConnectionStage,
-    module=this_module,
-    all_ops=all_common_ops,
-    handled_ops=[
-        pipeline_ops_base.ConnectOperation,
-        pipeline_ops_base.DisconnectOperation,
-        pipeline_ops_base.EnableFeatureOperation,
-        pipeline_ops_base.DisableFeatureOperation,
-        pipeline_ops_base.SendIotRequestAndWaitForResponseOperation,
-        pipeline_ops_base.SendIotRequestOperation,
-    ],
-    all_events=all_common_events,
-    handled_events=[],
-)
 
 
 # Workaround for flake8.  A class with this name is actually created inside
@@ -113,6 +97,380 @@ TestPipelineRootStagePipelineThreading.test_runs_callback_in_callback_thread = (
 TestPipelineRootStagePipelineThreading.test_runs_operation_in_pipeline_thread = (
     _test_pipeline_root_runs_operation_in_pipeline_thread
 )
+
+pipeline_stage_test.add_base_pipeline_stage_tests(
+    cls=pipeline_stages_base.EnsureConnectionStage,
+    module=this_module,
+    all_ops=all_common_ops,
+    handled_ops=[
+        pipeline_ops_mqtt.MQTTPublishOperation,
+        pipeline_ops_mqtt.MQTTSubscribeOperation,
+        pipeline_ops_mqtt.MQTTUnsubscribeOperation,
+    ],
+    all_events=all_common_events,
+    handled_events=[],
+)
+
+fake_topic = "__fake_topic__"
+fake_payload = "__fake_payload__"
+ops_that_cause_connection = [
+    {
+        "op_class": pipeline_ops_mqtt.MQTTPublishOperation,
+        "op_init_kwargs": {"topic": fake_topic, "payload": fake_payload},
+    },
+    {"op_class": pipeline_ops_mqtt.MQTTSubscribeOperation, "op_init_kwargs": {"topic": fake_topic}},
+    {
+        "op_class": pipeline_ops_mqtt.MQTTUnsubscribeOperation,
+        "op_init_kwargs": {"topic": fake_topic},
+    },
+]
+
+
+@pytest.mark.parametrize(
+    "params",
+    ops_that_cause_connection,
+    ids=[x["op_class"].__name__ for x in ops_that_cause_connection],
+)
+@pytest.mark.describe("EnsureConnectionStage - .run_op() -- called with connect operation")
+class TestEnsureConnectionStageRunOp(object):
+    @pytest.fixture
+    def op(self, mocker, params):
+        op = params["op_class"](**params["op_init_kwargs"])
+        op.callback = mocker.MagicMock()
+        return op
+
+    @pytest.fixture
+    def stage(self, mocker):
+        stage = make_mock_stage(
+            mocker=mocker, stage_to_make=pipeline_stages_base.EnsureConnectionStage
+        )
+        stage.next.run_op = mocker.MagicMock()
+        return stage
+
+    @pytest.mark.it("Passes the operation down the pipline when the transport is already connected")
+    def test_operation_alrady_connected(self, params, op, stage):
+        stage.connected = True
+
+        stage.run_op(op)
+
+        assert stage.next.run_op.call_count == 1
+        assert stage.next.run_op.call_args[0][0] == op
+
+    @pytest.mark.it(
+        "Sends a ConnectOperation instead of the op down the pipeline if the transport is not connected"
+    )
+    def test_sends_connect(self, params, op, stage):
+        stage.connected = False
+
+        stage.run_op(op)
+
+        assert stage.next.run_op.call_count == 1
+        assert isinstance(stage.next.run_op.call_args[0][0], pipeline_ops_base.ConnectOperation)
+
+    @pytest.mark.it(
+        "Calls the op's callback with the error from the ConnectOperation is that operation fails"
+    )
+    def test_connect_failure(self, params, op, stage, fake_exception):
+        stage.connected = False
+
+        stage.run_op(op)
+        connect_op = stage.next.run_op.call_args[0][0]
+        connect_op.error = fake_exception
+        operation_flow.complete_op(stage=stage.next, op=connect_op)
+
+        assert_callback_failed(op=op, error=fake_exception)
+
+    @pytest.mark.it("Waits for the ConnectOperation to complete before pasing the operation down")
+    def test_connect_success(self, params, op, stage):
+        stage.connected = False
+
+        stage.run_op(op)
+        assert stage.next.run_op.call_count == 1
+        connect_op = stage.next.run_op.call_args[0][0]
+        operation_flow.complete_op(stage=stage.next, op=connect_op)
+
+        assert stage.next.run_op.call_count == 2
+        assert stage.next.run_op.call_args[0][0] == op
+
+    @pytest.mark.it("calls the op's callback when the operation is complete after connecting")
+    def test_operation_complete(self, params, op, stage):
+        stage.connected = False
+
+        stage.run_op(op)
+        connect_op = stage.next.run_op.call_args[0][0]
+        operation_flow.complete_op(stage=stage.next, op=connect_op)
+
+        operation_flow.complete_op(stage=stage.next, op=op)
+        assert_callback_succeeded(op=op)
+
+    @pytest.mark.it("calls the op's callback when the operation fails after connecting")
+    def test_operation_fails(self, params, op, stage, fake_exception):
+        stage.connected = False
+
+        stage.run_op(op)
+        connect_op = stage.next.run_op.call_args[0][0]
+        operation_flow.complete_op(stage=stage.next, op=connect_op)
+        op.error = fake_exception
+        operation_flow.complete_op(stage=stage.next, op=op)
+
+        assert_callback_failed(op=op, error=fake_exception)
+
+
+pipeline_stage_test.add_base_pipeline_stage_tests(
+    cls=pipeline_stages_base.SerializeConnectOpsStage,
+    module=this_module,
+    all_ops=all_common_ops,
+    handled_ops=[
+        pipeline_ops_base.ConnectOperation,
+        pipeline_ops_base.DisconnectOperation,
+        pipeline_ops_base.ReconnectOperation,
+    ],
+    all_events=all_common_events,
+    handled_events=[],
+)
+
+connect_ops = [
+    {"op_class": pipeline_ops_base.ConnectOperation, "connected_flag_required_to_run": False},
+    {"op_class": pipeline_ops_base.DisconnectOperation, "connected_flag_required_to_run": True},
+    {"op_class": pipeline_ops_base.ReconnectOperation, "connected_flag_required_to_run": True},
+]
+
+
+class FakeOperation(pipeline_ops_base.PipelineOperation):
+    pass
+
+
+@pytest.mark.describe("SerializeConnectOpsStage - .run_op() -- called with connect operation")
+class TestSerializeConnectOpStageRunOp(object):
+    @pytest.fixture
+    def stage(self, mocker):
+        stage = make_mock_stage(
+            mocker=mocker, stage_to_make=pipeline_stages_base.SerializeConnectOpsStage
+        )
+        stage.next.run_op = mocker.MagicMock()
+        return stage
+
+    @pytest.fixture
+    def connect_op(self, mocker, params):
+        return params["op_class"](callback=mocker.MagicMock())
+
+    @pytest.fixture
+    def fake_op(self, mocker):
+        return FakeOperation(callback=mocker.MagicMock())
+
+    @pytest.fixture
+    def fake_ops(self, mocker):
+        return [
+            FakeOperation(callback=mocker.MagicMock()),
+            FakeOperation(callback=mocker.MagicMock()),
+            FakeOperation(callback=mocker.MagicMock()),
+        ]
+
+    @pytest.mark.it(
+        "Immediately completes a ConnectOperation if the transport is already connected"
+    )
+    def test_connect_while_connected(self, stage, mocker):
+        op = pipeline_ops_base.ConnectOperation(callback=mocker.MagicMock())
+        stage.connected = True
+        stage.run_op(op)
+        assert_callback_succeeded(op=op)
+
+    @pytest.mark.it(
+        "Immediately completes a DisconnectOperation if the transport is already disconnected"
+    )
+    def test_disconnect_while_disconnected(self, stage, mocker):
+        op = pipeline_ops_base.DisconnectOperation(callback=mocker.MagicMock())
+        stage.connected = False
+        stage.run_op(op)
+        assert_callback_succeeded(op=op)
+
+    @pytest.mark.it(
+        "Immediately passes the operation down if an operation is not alrady being serialized"
+    )
+    def test_passes_op_when_not_blocked(self, stage, mocker, fake_op):
+        stage.run_op(fake_op)
+        assert stage.next.run_op.call_count == 1
+        assert stage.next.run_op.call_args[0][0] == fake_op
+
+    @pytest.mark.parametrize(
+        "params", connect_ops, ids=[x["op_class"].__name__ for x in connect_ops]
+    )
+    @pytest.mark.it(
+        "Does not pass the operation down if a different operation is currently being serialized"
+    )
+    def test_does_not_pass_op_if_blocked(self, params, stage, connect_op, fake_op):
+        stage.connected = params["connected_flag_required_to_run"]
+        stage.run_op(connect_op)
+        stage.run_op(fake_op)
+
+        assert stage.next.run_op.call_count == 1
+        assert stage.next.run_op.call_args[0][0] == connect_op
+
+    @pytest.mark.parametrize(
+        "params", connect_ops, ids=[x["op_class"].__name__ for x in connect_ops]
+    )
+    @pytest.mark.it(
+        "Waits for the currently serialized operation to complete before passing the op down"
+    )
+    def test_waits_for_serialized_op_to_complete_before_passing_blocked_op(
+        self, params, stage, connect_op, fake_op
+    ):
+        stage.connected = params["connected_flag_required_to_run"]
+        stage.run_op(connect_op)
+        stage.run_op(fake_op)
+        operation_flow.complete_op(stage=stage.next, op=connect_op)
+
+        assert stage.next.run_op.call_count == 2
+        assert stage.next.run_op.call_args[0][0] == fake_op
+
+    @pytest.mark.parametrize(
+        "params", connect_ops, ids=[x["op_class"].__name__ for x in connect_ops]
+    )
+    @pytest.mark.it("Fails the operation if currently serialized option fails")
+    def test_fails_blocked_op_if_serialized_op_fails(
+        self, params, stage, connect_op, fake_op, fake_exception
+    ):
+        stage.connected = params["connected_flag_required_to_run"]
+        stage.run_op(connect_op)
+        stage.run_op(fake_op)
+        connect_op.error = fake_exception
+        operation_flow.complete_op(stage=stage.next, op=connect_op)
+        assert_callback_failed(op=fake_op, error=fake_exception)
+
+    @pytest.mark.parametrize(
+        "params", connect_ops, ids=[x["op_class"].__name__ for x in connect_ops]
+    )
+    @pytest.mark.it("Can pend multiple operations while waiting for a serialized operation")
+    def test_blocks_multiple_ops(self, params, stage, connect_op, fake_ops):
+        stage.connected = params["connected_flag_required_to_run"]
+        stage.run_op(connect_op)
+        for op in fake_ops:
+            stage.run_op(op)
+        assert stage.next.run_op.call_count == 1
+
+    @pytest.mark.parametrize(
+        "params", connect_ops, ids=[x["op_class"].__name__ for x in connect_ops]
+    )
+    @pytest.mark.it("Passes down all pending operations after the serialized operation completes")
+    def test_unblocks_multiple_ops(self, params, stage, connect_op, fake_ops):
+        stage.connected = params["connected_flag_required_to_run"]
+        stage.run_op(connect_op)
+        for op in fake_ops:
+            stage.run_op(op)
+
+        operation_flow.complete_op(stage=stage.next, op=connect_op)
+
+        assert stage.next.run_op.call_count == 1 + len(fake_ops)
+
+        # zip our ops and our calls together and make sure they match
+        run_ops = zip(fake_ops, stage.next.run_op.call_args_list[1:])
+        for run_op in run_ops:
+            op = run_op[0]
+            call_args = run_op[1]
+            assert op == call_args[0][0]
+
+    @pytest.mark.parametrize(
+        "params", connect_ops, ids=[x["op_class"].__name__ for x in connect_ops]
+    )
+    @pytest.mark.it("Fails all pending operations after the seriazed operation fails")
+    def test_fails_multiple_ops(self, params, stage, connect_op, fake_ops, fake_exception):
+        stage.connected = params["connected_flag_required_to_run"]
+        stage.run_op(connect_op)
+        for op in fake_ops:
+            stage.run_op(op)
+
+        connect_op.error = fake_exception
+        operation_flow.complete_op(stage=stage.next, op=connect_op)
+
+        for op in fake_ops:
+            assert_callback_failed(op=op, error=fake_exception)
+
+    @pytest.mark.it(
+        "Does not pass down operations in the queue if an operation in the queue gets serialized"
+    )
+    def test_re_blocks_ops_from_queue(self, stage, mocker):
+        first_connect = pipeline_ops_base.ConnectOperation(callback=mocker.MagicMock())
+        first_fake_op = FakeOperation(callback=mocker.MagicMock())
+        second_connect = pipeline_ops_base.ReconnectOperation(callback=mocker.MagicMock())
+        second_fake_op = FakeOperation(callback=mocker.MagicMock())
+
+        stage.run_op(first_connect)
+        stage.run_op(first_fake_op)
+        stage.run_op(second_connect)
+        stage.run_op(second_fake_op)
+
+        # at this point, ops are pended waiting for the first connect to complete.  Verify this and complete the connect.
+        assert stage.next.run_op.call_count == 1
+        assert stage.next.run_op.call_args[0][0] == first_connect
+        operation_flow.complete_op(stage=stage.next, op=first_connect)
+
+        # The connect is complete.  This passes down first_fake_op and second_connect and second_fake_op gets pended waiting i
+        # for second_connect to complete.
+        # Note: this isn't ideal.  In a perfect world, second_connect wouldn't start until first_fake_op is complete, but we
+        # dont have this logic in place yet.
+        assert stage.next.run_op.call_count == 3
+        assert stage.next.run_op.call_args_list[1][0][0] == first_fake_op
+        assert stage.next.run_op.call_args_list[2][0][0] == second_connect
+
+        # now, complete second_connect to give second_fake_op a chance to get passed down
+        operation_flow.complete_op(stage=stage.next, op=second_connect)
+        assert stage.next.run_op.call_count == 4
+        assert stage.next.run_op.call_args_list[3][0][0] == second_fake_op
+
+    @pytest.mark.parametrize(
+        "params",
+        [
+            pytest.param(
+                {
+                    "pre_connected_flag": True,
+                    "first_connect_op": pipeline_ops_base.DisconnectOperation,
+                    "mid_connect_flag": False,
+                    "second_connect_op": pipeline_ops_base.DisconnectOperation,
+                },
+                id="Disconnect followed by Disconnect",
+            ),
+            pytest.param(
+                {
+                    "pre_connected_flag": False,
+                    "first_connect_op": pipeline_ops_base.ConnectOperation,
+                    "mid_connect_flag": True,
+                    "second_connect_op": pipeline_ops_base.ConnectOperation,
+                },
+                id="Connect followed by Connect",
+            ),
+            pytest.param(
+                {
+                    "pre_connected_flag": True,
+                    "first_connect_op": pipeline_ops_base.ReconnectOperation,
+                    "mid_connect_flag": True,
+                    "second_connect_op": pipeline_ops_base.ConnectOperation,
+                },
+                id="Reconnect followed by Connect",
+            ),
+        ],
+    )
+    @pytest.mark.it(
+        "Immediately completes a second op which was waiting for a first op that succeeded"
+    )
+    def test_immediately_completes_second_op(self, stage, params, mocker):
+        first_connect_op = params["first_connect_op"](mocker.MagicMock())
+        second_connect_op = params["second_connect_op"](mocker.MagicMock())
+        stage.connected = params["pre_connected_flag"]
+
+        stage.run_op(first_connect_op)
+        stage.run_op(second_connect_op)
+
+        # first_connect_op has been passed down.  second_connect_op is waiting for first disconnect to complete.
+        assert stage.next.run_op.call_count == 1
+        assert stage.next.run_op.call_args[0][0] == first_connect_op
+
+        # complete first_connect_op
+        stage.connected = params["mid_connect_flag"]
+        operation_flow.complete_op(stage=stage.next, op=first_connect_op)
+
+        # second connect_op should be completed without having been passed down.
+        assert stage.next.run_op.call_count == 1
+        assert_callback_succeeded(op=second_connect_op)
 
 
 pipeline_stage_test.add_base_pipeline_stage_tests(

--- a/azure-iot-device/tests/common/pipeline/test_pipeline_stages_mqtt.py
+++ b/azure-iot-device/tests/common/pipeline/test_pipeline_stages_mqtt.py
@@ -154,11 +154,6 @@ class TestMQTTProviderRunOpWithSetConnectionArgs(object):
             == stage._on_mqtt_message_received
         )
 
-    @pytest.mark.it("Sets the transport attribute on the root of the pipeline")
-    def test_sets_transport_attribute_on_root(self, stage, transport, op_set_connection_args):
-        stage.run_op(op_set_connection_args)
-        assert stage.previous.transport == transport.return_value
-
     @pytest.mark.it("Completes with success if no exception")
     def test_succeeds(self, stage, transport, op_set_connection_args):
         stage.run_op(op_set_connection_args)

--- a/azure-iot-device/tests/iothub/pipeline/test_iothub_pipeline.py
+++ b/azure-iot-device/tests/iothub/pipeline/test_iothub_pipeline.py
@@ -82,9 +82,9 @@ class TestIoTHubPipelineInstantiation(object):
     @pytest.mark.it("Configures the pipeline to trigger handlers in response to external events")
     def test_handlers_configured(self, auth_provider):
         pipeline = IoTHubPipeline(auth_provider)
-        assert pipeline._pipeline.on_pipeline_event is not None
-        assert pipeline._pipeline.on_connected is not None
-        assert pipeline._pipeline.on_disconnected is not None
+        assert pipeline._pipeline.on_pipeline_event_handler is not None
+        assert pipeline._pipeline.on_connected_handler is not None
+        assert pipeline._pipeline.on_disconnected_handler is not None
 
     @pytest.mark.it("Configures the pipeline with a series of PipelineStages")
     def test_pipeline_configuration(self, auth_provider):
@@ -775,14 +775,14 @@ class TestIoTHubPipelineEVENTConnect(object):
         assert mock_handler.call_count == 0
 
         # Trigger the connect
-        pipeline._pipeline.on_connected()
+        pipeline._pipeline.on_connected_handler()
 
         assert mock_handler.call_count == 1
         assert mock_handler.call_args == mocker.call()
 
     @pytest.mark.it("Does nothing if the 'on_connected' handler is not set")
     def test_without_handler(self, pipeline):
-        pipeline._pipeline.on_connected()
+        pipeline._pipeline.on_connected_handler()
 
         # No assertions required - not throwing an exception means the test passed
 
@@ -797,14 +797,14 @@ class TestIoTHubPipelineEVENTDisconnect(object):
         assert mock_handler.call_count == 0
 
         # Trigger the connect
-        pipeline._pipeline.on_disconnected()
+        pipeline._pipeline.on_disconnected_handler()
 
         assert mock_handler.call_count == 1
         assert mock_handler.call_args == mocker.call()
 
     @pytest.mark.it("Does nothing if the 'on_disconnected' handler is not set")
     def test_without_handler(self, pipeline):
-        pipeline._pipeline.on_disconnected()
+        pipeline._pipeline.on_disconnected_handler()
 
         # No assertions required - not throwing an exception means the test passed
 
@@ -824,7 +824,7 @@ class TestIoTHubPipelineEVENTRecieveC2DMessage(object):
         c2d_event = pipeline_events_iothub.C2DMessageEvent(message)
 
         # Trigger the event
-        pipeline._pipeline.on_pipeline_event(c2d_event)
+        pipeline._pipeline.on_pipeline_event_handler(c2d_event)
 
         assert mock_handler.call_count == 1
         assert mock_handler.call_args == mocker.call(message)
@@ -832,7 +832,7 @@ class TestIoTHubPipelineEVENTRecieveC2DMessage(object):
     @pytest.mark.it("Drops the message if the 'on_c2d_message_received' handler is not set")
     def test_no_handler(self, pipeline, message):
         c2d_event = pipeline_events_iothub.C2DMessageEvent(message)
-        pipeline._pipeline.on_pipeline_event(c2d_event)
+        pipeline._pipeline.on_pipeline_event_handler(c2d_event)
 
         # No assertions required - not throwing an exception means the test passed
 
@@ -853,7 +853,7 @@ class TestIoTHubPipelineEVENTReceiveInputMessage(object):
         input_message_event = pipeline_events_iothub.InputMessageEvent(input_name, message)
 
         # Trigger the event
-        pipeline._pipeline.on_pipeline_event(input_message_event)
+        pipeline._pipeline.on_pipeline_event_handler(input_message_event)
 
         assert mock_handler.call_count == 1
         assert mock_handler.call_args == mocker.call(input_name, message)
@@ -862,7 +862,7 @@ class TestIoTHubPipelineEVENTReceiveInputMessage(object):
     def test_no_handler(self, pipeline, message):
         input_name = "some_input"
         input_message_event = pipeline_events_iothub.InputMessageEvent(input_name, message)
-        pipeline._pipeline.on_pipeline_event(input_message_event)
+        pipeline._pipeline.on_pipeline_event_handler(input_message_event)
 
         # No assertions required - not throwing an exception means the test passed
 
@@ -882,7 +882,7 @@ class TestIoTHubPipelineEVENTReceiveMethodRequest(object):
         method_request_event = pipeline_events_iothub.MethodRequestEvent(method_request)
 
         # Trigger the event
-        pipeline._pipeline.on_pipeline_event(method_request_event)
+        pipeline._pipeline.on_pipeline_event_handler(method_request_event)
 
         assert mock_handler.call_count == 1
         assert mock_handler.call_args == mocker.call(method_request)
@@ -892,7 +892,7 @@ class TestIoTHubPipelineEVENTReceiveMethodRequest(object):
     )
     def test_no_handler(self, pipeline, method_request):
         method_request_event = pipeline_events_iothub.MethodRequestEvent(method_request)
-        pipeline._pipeline.on_pipeline_event(method_request_event)
+        pipeline._pipeline.on_pipeline_event_handler(method_request_event)
 
         # No assertions required - not throwing an exception means the test passed
 
@@ -912,7 +912,7 @@ class TestIoTHubPipelineEVENTReceiveDesiredPropertiesPatch(object):
         twin_patch_event = pipeline_events_iothub.TwinDesiredPropertiesPatchEvent(twin_patch)
 
         # Trigger the event
-        pipeline._pipeline.on_pipeline_event(twin_patch_event)
+        pipeline._pipeline.on_pipeline_event_handler(twin_patch_event)
 
         assert mock_handler.call_count == 1
         assert mock_handler.call_args == mocker.call(twin_patch)
@@ -920,6 +920,6 @@ class TestIoTHubPipelineEVENTReceiveDesiredPropertiesPatch(object):
     @pytest.mark.it("Drops the twin patch if the 'on_twin_patch_received' handler is not set")
     def test_no_handler(self, pipeline, twin_patch):
         twin_patch_event = pipeline_events_iothub.TwinDesiredPropertiesPatchEvent(twin_patch)
-        pipeline._pipeline.on_pipeline_event(twin_patch_event)
+        pipeline._pipeline.on_pipeline_event_handler(twin_patch_event)
 
         # No assertions required - not throwing an exception means the test passed

--- a/azure-iot-device/tests/iothub/pipeline/test_iothub_pipeline.py
+++ b/azure-iot-device/tests/iothub/pipeline/test_iothub_pipeline.py
@@ -96,8 +96,9 @@ class TestIoTHubPipelineInstantiation(object):
             pipeline_stages_iothub.UseAuthProviderStage,
             pipeline_stages_iothub.HandleTwinOperationsStage,
             pipeline_stages_base.CoordinateRequestAndResponseStage,
-            pipeline_stages_base.EnsureConnectionStage,
             pipeline_stages_iothub_mqtt.IoTHubMQTTConverterStage,
+            pipeline_stages_base.EnsureConnectionStage,
+            pipeline_stages_base.SerializeConnectOpsStage,
             pipeline_stages_mqtt.MQTTTransportStage,
         ]
 

--- a/azure-iot-device/tests/iothub/pipeline/test_pipeline_ops_iothub.py
+++ b/azure-iot-device/tests/iothub/pipeline/test_pipeline_ops_iothub.py
@@ -41,33 +41,28 @@ pipeline_data_object_test.add_operation_test(
     module=this_module,
     positional_arguments=["message"],
     keyword_arguments={"callback": None},
-    extra_defaults={"needs_connection": True},
 )
 pipeline_data_object_test.add_operation_test(
     cls=pipeline_ops_iothub.SendOutputEventOperation,
     module=this_module,
     positional_arguments=["message"],
     keyword_arguments={"callback": None},
-    extra_defaults={"needs_connection": True},
 )
 pipeline_data_object_test.add_operation_test(
     cls=pipeline_ops_iothub.SendMethodResponseOperation,
     module=this_module,
     positional_arguments=["method_response"],
     keyword_arguments={"callback": None},
-    extra_defaults={"needs_connection": True},
 )
 pipeline_data_object_test.add_operation_test(
     cls=pipeline_ops_iothub.GetTwinOperation,
     module=this_module,
     positional_arguments=[],
     keyword_arguments={"callback": None},
-    extra_defaults={"needs_connection": True},
 )
 pipeline_data_object_test.add_operation_test(
     cls=pipeline_ops_iothub.PatchTwinReportedPropertiesOperation,
     module=this_module,
     positional_arguments=["patch"],
     keyword_arguments={"callback": None},
-    extra_defaults={"needs_connection": True},
 )

--- a/azure-iot-device/tests/iothub/pipeline/test_pipeline_stages_iothub_mqtt.py
+++ b/azure-iot-device/tests/iothub/pipeline/test_pipeline_stages_iothub_mqtt.py
@@ -131,6 +131,7 @@ pipeline_stage_test.add_base_pipeline_stage_tests(
     handled_ops=ops_handled_by_this_stage,
     all_events=all_common_events + all_iothub_events,
     handled_events=events_handled_by_this_stage,
+    extra_initializer_defaults={"feature_to_topic": dict},
 )
 
 

--- a/azure-iot-device/tests/provisioning/pipeline/test_pipeline_ops_provisioning.py
+++ b/azure-iot-device/tests/provisioning/pipeline/test_pipeline_ops_provisioning.py
@@ -28,12 +28,10 @@ pipeline_data_object_test.add_operation_test(
     module=this_module,
     positional_arguments=["request_id", "request_payload"],
     keyword_arguments={"callback": None},
-    extra_defaults={"needs_connection": True},
 )
 pipeline_data_object_test.add_operation_test(
     cls=pipeline_ops_provisioning.SendQueryRequestOperation,
     module=this_module,
     positional_arguments=["request_id", "operation_id", "request_payload"],
     keyword_arguments={"callback": None},
-    extra_defaults={"needs_connection": True},
 )

--- a/azure-iot-device/tests/provisioning/pipeline/test_pipeline_stages_provisioning_mqtt.py
+++ b/azure-iot-device/tests/provisioning/pipeline/test_pipeline_stages_provisioning_mqtt.py
@@ -79,6 +79,7 @@ pipeline_stage_test.add_base_pipeline_stage_tests(
     handled_ops=ops_handled_by_this_stage,
     all_events=all_common_events + all_provisioning_events,
     handled_events=events_handled_by_this_stage,
+    extra_initializer_defaults={"action_to_topic": dict},
 )
 
 


### PR DESCRIPTION
…ct ops

This accomplishes 4 things:
1. more prep work for retry
2. prep work for renewing SAS token.  
3. brings us closer in line with track-2 work.
4. more code under test

The primary goal here is to separate the notions of "this operation needs the transport to be connected" and "connection operations need be serialized" into 2 different stages.  This is because the old code had these 2 things intertwined in a way that made adding new functionality difficult.  In particular, I'm adding support for reconnecting (this change) and I will be adding support to make sure there are no ops in progress before reconnecting (future change).
