### PR TITLE
Return pipeline errors to user by raising exceptions from the client …

### DIFF
--- a/azure-iot-device/azure/iot/device/common/evented_callback.py
+++ b/azure-iot-device/azure/iot/device/common/evented_callback.py
@@ -1,0 +1,75 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for
+# license information.
+# --------------------------------------------------------------------------
+import threading
+import logging
+import six
+
+logger = logging.getLogger(__name__)
+
+
+class EventedCallback(object):
+    """
+    A sync callback whose completion can be waited upon.
+    """
+
+    def __init__(self, return_arg_name=None):
+        """
+        Creates an instance of an EventedCallback.
+
+        """
+        # LBYL because this mistake doesn't cause an exception until the callback
+        # which is much later and very difficult to trace back to here.
+        if return_arg_name and not isinstance(return_arg_name, six.string_types):
+            raise TypeError("internal error: return_arg_name must be a string")
+
+        self.completion_event = threading.Event()
+        self.exception = None
+        self.result = None
+
+        def wrapping_callback(*args, **kwargs):
+            if "error" in kwargs and kwargs["error"]:
+                logger.error("Callback called with error {}".format(kwargs["error"]))
+                self.exception = kwargs["error"]
+            elif return_arg_name:
+                if return_arg_name in kwargs:
+                    self.result = kwargs[return_arg_name]
+                else:
+                    raise TypeError(
+                        "internal error: excepected argument with name '{}', did not get".format(
+                            return_arg_name
+                        )
+                    )
+            elif len(args) == 1:
+                self.result = args[0]
+
+            if self.exception:
+                logger.error(
+                    "Callback completed with error {}".format(self.exception),
+                    exc_info=self.exception,
+                )
+            else:
+                logger.info("Callback completed with result {}".format(self.result))
+
+            self.completion_event.set()
+
+        self.callback = wrapping_callback
+
+    def __call__(self, *args, **kwargs):
+        """
+        Calls the callback.
+        """
+        self.callback(*args, **kwargs)
+
+    def wait(self, *args, **kwargs):
+        """
+        Wait for the callback to be called, and return the results.
+        """
+        self.completion_event.wait(*args, **kwargs)
+
+        if self.exception:
+            raise self.exception
+        else:
+            return self.result

--- a/azure-iot-device/azure/iot/device/iothub/aio/async_clients.py
+++ b/azure-iot-device/azure/iot/device/iothub/aio/async_clients.py
@@ -66,13 +66,11 @@ class GenericIoTHubClient(AbstractIoTHubClient):
         logger.info("Connecting to Hub...")
         connect_async = async_adapter.emulate_async(self._iothub_pipeline.connect)
 
-        def sync_callback():
-            logger.info("Successfully connected to Hub")
-
-        callback = async_adapter.AwaitableCallback(sync_callback)
-
+        callback = async_adapter.AwaitableCallback()
         await connect_async(callback=callback)
         await callback.completion()
+
+        logger.info("Successfully connected to Hub")
 
     async def disconnect(self):
         """Disconnect the client from the Azure IoT Hub or Azure IoT Edge Hub instance.
@@ -80,13 +78,11 @@ class GenericIoTHubClient(AbstractIoTHubClient):
         logger.info("Disconnecting from Hub...")
         disconnect_async = async_adapter.emulate_async(self._iothub_pipeline.disconnect)
 
-        def sync_callback():
-            logger.info("Successfully disconnected from Hub")
-
-        callback = async_adapter.AwaitableCallback(sync_callback)
-
+        callback = async_adapter.AwaitableCallback()
         await disconnect_async(callback=callback)
         await callback.completion()
+
+        logger.info("Successfully disconnected from Hub")
 
     async def send_message(self, message):
         """Sends a message to the default events endpoint on the Azure IoT Hub or Azure IoT Edge Hub instance.
@@ -103,13 +99,11 @@ class GenericIoTHubClient(AbstractIoTHubClient):
         logger.info("Sending message to Hub...")
         send_message_async = async_adapter.emulate_async(self._iothub_pipeline.send_message)
 
-        def sync_callback():
-            logger.info("Successfully sent message to Hub")
-
-        callback = async_adapter.AwaitableCallback(sync_callback)
-
+        callback = async_adapter.AwaitableCallback()
         await send_message_async(message, callback=callback)
         await callback.completion()
+
+        logger.info("Successfully sent message to Hub")
 
     async def receive_method_request(self, method_name=None):
         """Receive a method request via the Azure IoT Hub or Azure IoT Edge Hub.
@@ -145,14 +139,13 @@ class GenericIoTHubClient(AbstractIoTHubClient):
             self._iothub_pipeline.send_method_response
         )
 
-        def sync_callback():
-            logger.info("Successfully sent method response to Hub")
-
-        callback = async_adapter.AwaitableCallback(sync_callback)
+        callback = async_adapter.AwaitableCallback()
 
         # TODO: maybe consolidate method_request, result and status into a new object
         await send_method_response_async(method_response, callback=callback)
         await callback.completion()
+
+        logger.info("Successfully sent method response to Hub")
 
     async def _enable_feature(self, feature_name):
         """Enable an Azure IoT Hub feature
@@ -163,13 +156,11 @@ class GenericIoTHubClient(AbstractIoTHubClient):
         logger.info("Enabling feature:" + feature_name + "...")
         enable_feature_async = async_adapter.emulate_async(self._iothub_pipeline.enable_feature)
 
-        def sync_callback():
-            logger.info("Successfully enabled feature:" + feature_name)
-
-        callback = async_adapter.AwaitableCallback(sync_callback)
-
+        callback = async_adapter.AwaitableCallback()
         await enable_feature_async(feature_name, callback=callback)
         await callback.completion()
+
+        logger.info("Successfully enabled feature:" + feature_name)
 
     async def get_twin(self):
         """
@@ -184,18 +175,10 @@ class GenericIoTHubClient(AbstractIoTHubClient):
 
         get_twin_async = async_adapter.emulate_async(self._iothub_pipeline.get_twin)
 
-        twin = None
-
-        def sync_callback(received_twin):
-            nonlocal twin
-            logger.info("Successfully retrieved twin")
-            twin = received_twin
-
-        callback = async_adapter.AwaitableCallback(sync_callback)
-
+        callback = async_adapter.AwaitableCallback(return_arg_name="twin")
         await get_twin_async(callback=callback)
-        await callback.completion()
-
+        twin = await callback.completion()
+        logger.info("Successfully retrieved twin")
         return twin
 
     async def patch_twin_reported_properties(self, reported_properties_patch):
@@ -217,13 +200,11 @@ class GenericIoTHubClient(AbstractIoTHubClient):
             self._iothub_pipeline.patch_twin_reported_properties
         )
 
-        def sync_callback():
-            logger.info("Successfully sent twin patch")
-
-        callback = async_adapter.AwaitableCallback(sync_callback)
-
+        callback = async_adapter.AwaitableCallback()
         await patch_twin_async(patch=reported_properties_patch, callback=callback)
         await callback.completion()
+
+        logger.info("Successfully sent twin patch")
 
     async def receive_twin_desired_properties_patch(self):
         """
@@ -320,13 +301,11 @@ class IoTHubModuleClient(GenericIoTHubClient, AbstractIoTHubModuleClient):
             self._iothub_pipeline.send_output_event
         )
 
-        def sync_callback():
-            logger.info("Successfully sent message to output: " + output_name)
-
-        callback = async_adapter.AwaitableCallback(sync_callback)
-
+        callback = async_adapter.AwaitableCallback()
         await send_output_event_async(message, callback=callback)
         await callback.completion()
+
+        logger.info("Successfully sent message to output: " + output_name)
 
     async def receive_message_on_input(self, input_name):
         """Receive an input message that has been sent from another Module to a specific input.

--- a/azure-iot-device/azure/iot/device/iothub/pipeline/iothub_pipeline.py
+++ b/azure-iot-device/azure/iot/device/iothub/pipeline/iothub_pipeline.py
@@ -6,6 +6,7 @@
 
 import logging
 import sys
+from azure.iot.device.common.evented_callback import EventedCallback
 from azure.iot.device.common.pipeline import (
     pipeline_stages_base,
     pipeline_ops_base,
@@ -96,22 +97,24 @@ class IoTHubPipeline(object):
         self._pipeline.on_connected_handler = _on_connected
         self._pipeline.on_disconnected_handler = _on_disconnected
 
-        def remove_this_code(call):
-            if call.error:
-                raise call.error
+        callback = EventedCallback()
 
         if isinstance(auth_provider, X509AuthenticationProvider):
             op = pipeline_ops_iothub.SetX509AuthProviderOperation(
-                auth_provider=auth_provider, callback=remove_this_code
+                auth_provider=auth_provider, callback=callback
             )
         else:  # Currently everything else goes via this block.
             op = pipeline_ops_iothub.SetAuthProviderOperation(
-                auth_provider=auth_provider, callback=remove_this_code
+                auth_provider=auth_provider, callback=callback
             )
 
         self._pipeline.run_op(op)
+        op = callback.wait()
+        if op.error:
+            logger.error("{} failed: {}".format(op.name, op.error))
+            raise op.error
 
-    def connect(self, callback=None):
+    def connect(self, callback):
         """
         Connect to the service.
 
@@ -119,16 +122,15 @@ class IoTHubPipeline(object):
         """
         logger.info("Starting ConnectOperation on the pipeline")
 
-        def on_complete(call):
-            if call.error:
-                # TODO we need error semantics on the client
-                sys.exit(1)  # TODO: raise an error instead
-            if callback:
+        def on_complete(op):
+            if op.error:
+                callback(error=op.error)
+            else:
                 callback()
 
         self._pipeline.run_op(pipeline_ops_base.ConnectOperation(callback=on_complete))
 
-    def disconnect(self, callback=None):
+    def disconnect(self, callback):
         """
         Disconnect from the service.
 
@@ -136,16 +138,15 @@ class IoTHubPipeline(object):
         """
         logger.info("Starting DisconnectOperation on the pipeline")
 
-        def on_complete(call):
-            if call.error:
-                # TODO we need error semantics on the client
-                sys.exit(1)
-            if callback:
+        def on_complete(op):
+            if op.error:
+                callback(error=op.error)
+            else:
                 callback()
 
         self._pipeline.run_op(pipeline_ops_base.DisconnectOperation(callback=on_complete))
 
-    def send_message(self, message, callback=None):
+    def send_message(self, message, callback):
         """
         Send a telemetry message to the service.
 
@@ -153,18 +154,17 @@ class IoTHubPipeline(object):
         :param callback: callback which is called when the message publish has been acknowledged by the service.
         """
 
-        def on_complete(call):
-            if call.error:
-                # TODO we need error semantics on the client
-                sys.exit(1)
-            if callback:
+        def on_complete(op):
+            if op.error:
+                callback(error=op.error)
+            else:
                 callback()
 
         self._pipeline.run_op(
             pipeline_ops_iothub.SendD2CMessageOperation(message=message, callback=on_complete)
         )
 
-    def send_output_event(self, message, callback=None):
+    def send_output_event(self, message, callback):
         """
         Send an output message to the service.
 
@@ -172,18 +172,17 @@ class IoTHubPipeline(object):
         :param callback: callback which is called when the message publish has been acknowledged by the service.
         """
 
-        def on_complete(call):
-            if call.error:
-                # TODO we need error semantics on the client
-                sys.exit(1)
-            if callback:
+        def on_complete(op):
+            if op.error:
+                callback(error=op.error)
+            else:
                 callback()
 
         self._pipeline.run_op(
             pipeline_ops_iothub.SendOutputEventOperation(message=message, callback=on_complete)
         )
 
-    def send_method_response(self, method_response, callback=None):
+    def send_method_response(self, method_response, callback):
         """
         Send a method response to the service.
 
@@ -192,11 +191,10 @@ class IoTHubPipeline(object):
         """
         logger.info("IoTHubPipeline send_method_response called")
 
-        def on_complete(call):
-            if call.error:
-                # TODO we need error semantics on the client
-                sys.exit(1)
-            if callback:
+        def on_complete(op):
+            if op.error:
+                callback(error=op.error)
+            else:
                 callback()
 
         self._pipeline.run_op(
@@ -213,15 +211,15 @@ class IoTHubPipeline(object):
         This callback should have one parameter, which will contain the requested twin when called.
         """
 
-        def on_complete(call):
-            if call.error:
-                sys.exit(1)
-            if callback:
-                callback(call.twin)
+        def on_complete(op):
+            if op.error:
+                callback(error=op.error, twin=None)
+            else:
+                callback(twin=op.twin)
 
         self._pipeline.run_op(pipeline_ops_iothub.GetTwinOperation(callback=on_complete))
 
-    def patch_twin_reported_properties(self, patch, callback=None):
+    def patch_twin_reported_properties(self, patch, callback):
         """
         Send a patch for a twin's reported properties to the service.
 
@@ -229,10 +227,10 @@ class IoTHubPipeline(object):
         :param callback: callback which is called when request has been acknowledged by the service.
         """
 
-        def on_complete(call):
-            if call.error:
-                sys.exit(1)
-            if callback:
+        def on_complete(op):
+            if op.error:
+                callback(error=op.error)
+            else:
                 callback()
 
         self._pipeline.run_op(
@@ -241,7 +239,7 @@ class IoTHubPipeline(object):
             )
         )
 
-    def enable_feature(self, feature_name, callback=None):
+    def enable_feature(self, feature_name, callback):
         """
         Enable the given feature by subscribing to the appropriate topics.
 
@@ -255,11 +253,10 @@ class IoTHubPipeline(object):
             raise ValueError("Invalid feature_name")
         self.feature_enabled[feature_name] = True
 
-        def on_complete(call):
-            if call.error:
-                # TODO we need error semantics on the client
-                sys.exit(1)
-            if callback:
+        def on_complete(op):
+            if op.error:
+                callback(error=op.error)
+            else:
                 callback()
 
         self._pipeline.run_op(
@@ -268,7 +265,7 @@ class IoTHubPipeline(object):
             )
         )
 
-    def disable_feature(self, feature_name, callback=None):
+    def disable_feature(self, feature_name, callback):
         """
         Disable the given feature by subscribing to the appropriate topics.
         :param callback: callback which is called when the feature is disabled
@@ -282,11 +279,10 @@ class IoTHubPipeline(object):
             raise ValueError("Invalid feature_name")
         self.feature_enabled[feature_name] = False
 
-        def on_complete(call):
-            if call.error:
-                # TODO we need error semantics on the client
-                sys.exit(1)
-            if callback:
+        def on_complete(op):
+            if op.error:
+                callback(error=op.error)
+            else:
                 callback()
 
         self._pipeline.run_op(

--- a/azure-iot-device/azure/iot/device/iothub/sync_clients.py
+++ b/azure-iot-device/azure/iot/device/iothub/sync_clients.py
@@ -8,7 +8,6 @@ Azure IoTHub Device SDK for Python.
 """
 
 import logging
-import threading
 from .abstract_clients import (
     AbstractIoTHubClient,
     AbstractIoTHubDeviceClient,
@@ -18,6 +17,7 @@ from .models import Message
 from .inbox_manager import InboxManager
 from .sync_inbox import SyncClientInbox
 from .pipeline import constant
+from azure.iot.device.common.evented_callback import EventedCallback
 
 logger = logging.getLogger(__name__)
 
@@ -68,14 +68,11 @@ class GenericIoTHubClient(AbstractIoTHubClient):
         """
         logger.info("Connecting to Hub...")
 
-        connect_complete = threading.Event()
-
-        def callback():
-            connect_complete.set()
-            logger.info("Successfully connected to Hub")
-
+        callback = EventedCallback()
         self._iothub_pipeline.connect(callback=callback)
-        connect_complete.wait()
+        callback.wait()
+
+        logger.info("Successfully connected to Hub")
 
     def disconnect(self):
         """Disconnect the client from the Azure IoT Hub or Azure IoT Edge Hub instance.
@@ -85,14 +82,11 @@ class GenericIoTHubClient(AbstractIoTHubClient):
         """
         logger.info("Disconnecting from Hub...")
 
-        disconnect_complete = threading.Event()
-
-        def callback():
-            disconnect_complete.set()
-            logger.info("Successfully disconnected from Hub")
-
+        callback = EventedCallback()
         self._iothub_pipeline.disconnect(callback=callback)
-        disconnect_complete.wait()
+        callback.wait()
+
+        logger.info("Successfully disconnected from Hub")
 
     def send_message(self, message):
         """Sends a message to the default events endpoint on the Azure IoT Hub or Azure IoT Edge Hub instance.
@@ -110,14 +104,12 @@ class GenericIoTHubClient(AbstractIoTHubClient):
             message = Message(message)
 
         logger.info("Sending message to Hub...")
-        send_complete = threading.Event()
 
-        def callback():
-            send_complete.set()
-            logger.info("Successfully sent message to Hub")
-
+        callback = EventedCallback()
         self._iothub_pipeline.send_message(message, callback=callback)
-        send_complete.wait()
+        callback.wait()
+
+        logger.info("Successfully sent message to Hub")
 
     def receive_method_request(self, method_name=None, block=True, timeout=None):
         """Receive a method request via the Azure IoT Hub or Azure IoT Edge Hub.
@@ -157,14 +149,12 @@ class GenericIoTHubClient(AbstractIoTHubClient):
         :type method_response: MethodResponse
         """
         logger.info("Sending method response to Hub...")
-        send_complete = threading.Event()
 
-        def callback():
-            send_complete.set()
-            logger.info("Successfully sent method response to Hub")
-
+        callback = EventedCallback()
         self._iothub_pipeline.send_method_response(method_response, callback=callback)
-        send_complete.wait()
+        callback.wait()
+
+        logger.info("Successfully sent method response to Hub")
 
     def _enable_feature(self, feature_name):
         """Enable an Azure IoT Hub feature.
@@ -176,14 +166,12 @@ class GenericIoTHubClient(AbstractIoTHubClient):
         See azure.iot.device.common.pipeline.constant for possible values
         """
         logger.info("Enabling feature:" + feature_name + "...")
-        enable_complete = threading.Event()
 
-        def callback():
-            enable_complete.set()
-            logger.info("Successfully enabled feature:" + feature_name)
-
+        callback = EventedCallback()
         self._iothub_pipeline.enable_feature(feature_name, callback=callback)
-        enable_complete.wait()
+        callback.wait()
+
+        logger.info("Successfully enabled feature:" + feature_name)
 
     def get_twin(self):
         """
@@ -197,21 +185,12 @@ class GenericIoTHubClient(AbstractIoTHubClient):
         if not self._iothub_pipeline.feature_enabled[constant.TWIN]:
             self._enable_feature(constant.TWIN)
 
-        # hack to work aroud lack of the "nonlocal" keyword in 2.7.  The non-local "context"
-        # object can be read and modified inside the inner function.
-        # (https://stackoverflow.com/a/28433571)
-        class context:
-            twin = None
+        callback = EventedCallback(return_arg_name="twin")
+        self._iothub_pipeline.get_twin(callback=callback)
+        twin = callback.wait()
 
-        op_complete = threading.Event()
-
-        def on_pipeline_op_complete(retrieved_twin):
-            context.twin = retrieved_twin
-            op_complete.set()
-
-        self._iothub_pipeline.get_twin(callback=on_pipeline_op_complete)
-        op_complete.wait()
-        return context.twin
+        logger.info("Successfully retrieved twin")
+        return twin
 
     def patch_twin_reported_properties(self, reported_properties_patch):
         """
@@ -229,16 +208,13 @@ class GenericIoTHubClient(AbstractIoTHubClient):
         if not self._iothub_pipeline.feature_enabled[constant.TWIN]:
             self._enable_feature(constant.TWIN)
 
-        op_complete = threading.Event()
-
-        def on_pipeline_op_complete():
-            op_complete.set()
-
+        callback = EventedCallback()
         self._iothub_pipeline.patch_twin_reported_properties(
-            patch=reported_properties_patch, callback=on_pipeline_op_complete
+            patch=reported_properties_patch, callback=callback
         )
-        op_complete.wait()
-        print("Done with patch")
+        callback.wait()
+
+        logger.info("Successfully patched twin")
 
     def receive_twin_desired_properties_patch(self, block=True, timeout=None):
         """
@@ -355,14 +331,12 @@ class IoTHubModuleClient(GenericIoTHubClient, AbstractIoTHubModuleClient):
         message.output_name = output_name
 
         logger.info("Sending message to output:" + output_name + "...")
-        send_complete = threading.Event()
 
-        def callback():
-            logger.info("Successfully sent message to output: " + output_name)
-            send_complete.set()
-
+        callback = EventedCallback()
         self._iothub_pipeline.send_output_event(message, callback=callback)
-        send_complete.wait()
+        callback.wait()
+
+        logger.info("Successfully sent message to output: " + output_name)
 
     def receive_message_on_input(self, input_name, block=True, timeout=None):
         """Receive an input message that has been sent from another Module to a specific input.

--- a/azure-iot-device/azure/iot/device/provisioning/abstract_provisioning_device_client.py
+++ b/azure-iot-device/azure/iot/device/provisioning/abstract_provisioning_device_client.py
@@ -117,7 +117,7 @@ class AbstractProvisioningDeviceClient(object):
         pass
 
 
-def log_on_register_complete(result=None, error=None):
+def log_on_register_complete(result=None):
     # This could be a failed/successful registration result from DPS
     # or a error from polling machine. Response should be given appropriately
     if result is not None:
@@ -125,5 +125,3 @@ def log_on_register_complete(result=None, error=None):
             logger.info("Successfully registered with Provisioning Service")
         else:  # There be other statuses
             logger.error("Failed registering with Provisioning Service")
-    if error is not None:  # This can only happen when the polling machine runs into error
-        logger.error(error)

--- a/azure-iot-device/azure/iot/device/provisioning/aio/async_provisioning_device_client.py
+++ b/azure-iot-device/azure/iot/device/provisioning/aio/async_provisioning_device_client.py
@@ -45,14 +45,12 @@ class ProvisioningDeviceClient(AbstractProvisioningDeviceClient):
         logger.info("Registering with Provisioning Service...")
         register_async = async_adapter.emulate_async(self._polling_machine.register)
 
-        def sync_on_register_complete(result=None, error=None):
-            log_on_register_complete(result, error)
-            return result
-
-        callback = async_adapter.AwaitableCallback(sync_on_register_complete)
-
+        callback = async_adapter.AwaitableCallback(return_arg_name="result")
         await register_async(callback=callback)
-        return await callback.completion()
+        result = await callback.completion()
+
+        log_on_register_complete(result)
+        return result
 
     async def cancel(self):
         """
@@ -64,10 +62,8 @@ class ProvisioningDeviceClient(AbstractProvisioningDeviceClient):
         logger.info("Disconnecting from Provisioning Service...")
         cancel_async = async_adapter.emulate_async(self._polling_machine.cancel)
 
-        def sync_on_cancel_complete():
-            logger.info("Successfully cancelled the current registration process")
-
-        callback = async_adapter.AwaitableCallback(sync_on_cancel_complete)
-
+        callback = async_adapter.AwaitableCallback()
         await cancel_async(callback=callback)
         await callback.completion()
+
+        logger.info("Successfully cancelled the current registration process")

--- a/azure-iot-device/azure/iot/device/provisioning/internal/polling_machine.py
+++ b/azure-iot-device/azure/iot/device/provisioning/internal/polling_machine.py
@@ -420,7 +420,7 @@ class PollingMachine(object):
         if callback:
             self._register_callback = None
             try:
-                callback(None, self._registration_error)
+                callback(error=self._registration_error)
             except Exception:
                 logger.error("Unexpected error calling callback supplied to register")
                 logger.error(traceback.format_exc())
@@ -440,7 +440,7 @@ class PollingMachine(object):
         if callback:
             self._register_callback = None
             try:
-                callback(self._registration_result, None)
+                callback(result=self._registration_result)
             except Exception:
                 logger.error("Unexpected error calling callback supplied to register")
                 logger.error(traceback.format_exc())

--- a/azure-iot-device/azure/iot/device/provisioning/pipeline/provisioning_pipeline.py
+++ b/azure-iot-device/azure/iot/device/provisioning/pipeline/provisioning_pipeline.py
@@ -5,6 +5,7 @@
 # --------------------------------------------------------------------------
 
 import logging
+from azure.iot.device.common.evented_callback import EventedCallback
 from azure.iot.device.common.pipeline import pipeline_stages_base
 from azure.iot.device.common.pipeline import pipeline_ops_base
 from azure.iot.device.common.pipeline import pipeline_stages_mqtt
@@ -66,22 +67,24 @@ class ProvisioningPipeline(object):
         self._pipeline.on_connected_handler = _on_connected
         self._pipeline.on_disconnected_handler = _on_disconnected
 
-        def remove_this_code(call):
-            if call.error:
-                raise call.error
+        callback = EventedCallback()
 
         if isinstance(security_client, X509SecurityClient):
             op = pipeline_ops_provisioning.SetX509SecurityClientOperation(
-                security_client=security_client, callback=remove_this_code
+                security_client=security_client, callback=callback
             )
         elif isinstance(security_client, SymmetricKeySecurityClient):
             op = pipeline_ops_provisioning.SetSymmetricKeySecurityClientOperation(
-                security_client=security_client, callback=remove_this_code
+                security_client=security_client, callback=callback
             )
         else:
             logger.error("Provisioning not equipped to handle other security client.")
 
         self._pipeline.run_op(op)
+        op = callback.wait()
+        if op.error:
+            logger.error("{} failed: {}".format(op.name, op.error))
+            raise op.error
 
     def connect(self, callback=None):
         """

--- a/azure-iot-device/azure/iot/device/provisioning/provisioning_device_client.py
+++ b/azure-iot-device/azure/iot/device/provisioning/provisioning_device_client.py
@@ -7,7 +7,7 @@
 This module contains one of the implementations of the Provisioning Device Client which uses Symmetric Key authentication.
 """
 import logging
-from threading import Event
+from azure.iot.device.common.evented_callback import EventedCallback
 from .abstract_provisioning_device_client import AbstractProvisioningDeviceClient
 from .abstract_provisioning_device_client import log_on_register_complete
 from .internal.polling_machine import PollingMachine
@@ -40,23 +40,13 @@ class ProvisioningDeviceClient(AbstractProvisioningDeviceClient):
         If a registration attempt is made while a previous registration is in progress it may throw an error.
         """
         logger.info("Registering with Provisioning Service...")
-        register_complete = Event()
 
-        # hack to work aroud lack of the "nonlocal" keyword in 2.7.  The non-local "context"
-        # object can be read and modified inside the inner function.
-        # (https://stackoverflow.com/a/28433571)
-        class context:
-            registration_result = None
+        register_complete = EventedCallback(return_arg_name="result")
+        self._polling_machine.register(callback=register_complete)
+        result = register_complete.wait()
 
-        def on_register_complete(result=None, error=None):
-            log_on_register_complete(result, error)
-            context.registration_result = result
-            register_complete.set()
-
-        self._polling_machine.register(callback=on_register_complete)
-
-        register_complete.wait()
-        return context.registration_result
+        log_on_register_complete(result)
+        return result
 
     def cancel(self):
         """
@@ -68,11 +58,9 @@ class ProvisioningDeviceClient(AbstractProvisioningDeviceClient):
         no registration process to cancel.
         """
         logger.info("Cancelling the current registration process")
-        cancel_complete = Event()
 
-        def on_cancel_complete():
-            cancel_complete.set()
-            logger.info("Successfully cancelled the current registration process")
-
-        self._polling_machine.cancel(callback=on_cancel_complete)
+        cancel_complete = EventedCallback()
+        self._polling_machine.cancel(callback=cancel_complete)
         cancel_complete.wait()
+
+        logger.info("Successfully cancelled the current registration process")

--- a/azure-iot-device/tests/common/test_evented_callback.py
+++ b/azure-iot-device/tests/common/test_evented_callback.py
@@ -1,0 +1,117 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for
+# license information.
+# --------------------------------------------------------------------------
+
+import pytest
+import logging
+from time import sleep
+from azure.iot.device.common.evented_callback import EventedCallback
+
+logging.basicConfig(level=logging.INFO)
+
+
+@pytest.mark.describe("EventedCallback")
+class TestEventedCallback(object):
+    @pytest.fixture
+    def fake_return_arg_name(self):
+        return "return_arg"
+
+    @pytest.fixture
+    def fake_return_arg_value(self):
+        return "__fake_return_arg_value__"
+
+    @pytest.fixture
+    def fake_error(self):
+        return RuntimeError("__fake_error__")
+
+    @pytest.mark.it("Can be instantiated with no args")
+    def test_instantiates_without_return_arg_name(self):
+        callback = EventedCallback()
+        assert isinstance(callback, EventedCallback)
+
+    @pytest.mark.it("Can be instantiated with a return_arg_name")
+    def test_instantiates_with_return_arg_name(self, fake_return_arg_name):
+        callback = EventedCallback(return_arg_name=fake_return_arg_name)
+        assert isinstance(callback, EventedCallback)
+
+    @pytest.mark.it("Raises a TypeError if return_arg_name is not a string")
+    def test_value_error_on_bad_return_arg_name(self):
+        with pytest.raises(TypeError):
+            EventedCallback(return_arg_name=1)
+
+    @pytest.mark.it(
+        "Sets the instance completion Event when a call is invoked on the instance (without return_arg_name)"
+    )
+    def test_calling_object_sets_event(self):
+        callback = EventedCallback()
+        assert not callback.completion_event.isSet()
+        callback()
+        sleep(0.1)  # wait to give time to complete the callback
+        assert callback.completion_event.isSet()
+        assert not callback.exception
+        callback.wait()
+
+    @pytest.mark.it(
+        "Returns the value of the first and only positional argument when a call is invoked on the instance (without return_arg_name)"
+    )
+    def test_returns_only_positional_arg(self):
+        fake_return_value = 1048
+        callback = EventedCallback()
+        assert not callback.completion_event.isSet()
+        callback(fake_return_value)
+        sleep(0.1)  # wait to give time to complete the callback
+        assert callback.completion_event.isSet()
+        assert not callback.exception
+        assert callback.wait() == fake_return_value
+
+    @pytest.mark.it(
+        "Sets the instance completion Event when a call is invoked on the instance (with return_arg_name)"
+    )
+    def test_calling_object_sets_event_with_return_arg_name(
+        self, fake_return_arg_name, fake_return_arg_value
+    ):
+        callback = EventedCallback(return_arg_name=fake_return_arg_name)
+        assert not callback.completion_event.isSet()
+        callback(return_arg=fake_return_arg_value)
+        sleep(0.1)  # wait to give time to complete the callback
+        assert callback.completion_event.isSet()
+        assert not callback.exception
+        assert callback.wait() == fake_return_arg_value
+
+    @pytest.mark.it(
+        "Raises an exception when a call is invoked on the instance without the correct return argument (with return_arg_name)"
+    )
+    def test_calling_object_raises_exception_if_return_arg_is_missing(
+        self, fake_return_arg_name, fake_return_arg_value
+    ):
+        callback = EventedCallback(return_arg_name=fake_return_arg_name)
+        with pytest.raises(TypeError):
+            callback()
+
+    @pytest.mark.it(
+        "Causes an error to be raised from the wait call when an error parameter is passed to the call (without return_arg_name)"
+    )
+    def test_raises_error_without_return_arg_name(self, fake_error):
+        callback = EventedCallback()
+        assert not callback.completion_event.isSet()
+        callback(error=fake_error)
+        sleep(0.1)  # wait to give time to complete the callback
+        assert callback.completion_event.isSet()
+        assert callback.exception == fake_error
+        with pytest.raises(fake_error.__class__):
+            callback.wait()
+
+    @pytest.mark.it(
+        "Causes an error to be raised from the wait call when an error parameter is passed to the call (with return_arg_name)"
+    )
+    def test_raises_error_with_return_arg_name(self, fake_return_arg_name, fake_error):
+        callback = EventedCallback(return_arg_name=fake_return_arg_name)
+        assert not callback.completion_event.isSet()
+        callback(error=fake_error)
+        sleep(0.1)  # wait to give time to complete the callback
+        assert callback.completion_event.isSet()
+        assert callback.exception == fake_error
+        with pytest.raises(fake_error.__class__):
+            callback.wait()

--- a/azure-iot-device/tests/iothub/client_fixtures.py
+++ b/azure-iot-device/tests/iothub/client_fixtures.py
@@ -174,31 +174,31 @@ class FakeIoTHubPipeline:
     def __init__(self):
         self.feature_enabled = {}  # This just has to be here for the spec
 
-    def connect(self, callback=None):
+    def connect(self, callback):
         callback()
 
-    def disconnect(self, callback=None):
+    def disconnect(self, callback):
         callback()
 
-    def enable_feature(self, feature_name, callback=None):
+    def enable_feature(self, feature_name, callback):
         callback()
 
-    def disable_feature(self, feature_name, callback=None):
+    def disable_feature(self, feature_name, callback):
         callback()
 
-    def send_message(self, event, callback=None):
+    def send_message(self, event, callback):
         callback()
 
-    def send_output_event(self, event, callback=None):
+    def send_output_event(self, event, callback):
         callback()
 
-    def send_method_response(self, method_response, callback=None):
+    def send_method_response(self, method_response, callback):
         callback()
 
-    def get_twin(self, callback=None):
-        callback(None)
+    def get_twin(self, callback):
+        callback(twin={})
 
-    def patch_twin_reported_properties(self, patch, callback=None):
+    def patch_twin_reported_properties(self, patch, callback):
         callback()
 
 

--- a/azure-iot-device/tests/iothub/pipeline/test_iothub_pipeline.py
+++ b/azure-iot-device/tests/iothub/pipeline/test_iothub_pipeline.py
@@ -11,6 +11,7 @@ from azure.iot.device.common.pipeline import (
     pipeline_stages_base,
     pipeline_stages_mqtt,
     pipeline_ops_base,
+    operation_flow,
 )
 from azure.iot.device.iothub.pipeline import (
     pipeline_stages_iothub,
@@ -52,6 +53,15 @@ def pipeline(mocker, auth_provider):
 @pytest.fixture
 def twin_patch():
     return {"key": "value"}
+
+
+# automatically mock the transport for all tests in this file.
+@pytest.fixture(autouse=True)
+def mock_transport(mocker):
+    print("mocking transport")
+    mocker.patch(
+        "azure.iot.device.common.pipeline.pipeline_stages_mqtt.MQTTTransport", autospec=True
+    )
 
 
 @pytest.mark.describe("IoTHubPipeline - Instantiation")
@@ -120,10 +130,10 @@ class TestIoTHubPipelineInstantiation(object):
         "Runs a SetAuthProviderOperation with the provided AuthenticationProvider on the pipeline, if using SAS based authentication"
     )
     def test_sas_auth(self, mocker, device_connection_string):
-        mocker.patch.object(pipeline_stages_base, "PipelineRootStage")
+        mocker.spy(pipeline_stages_base.PipelineRootStage, "run_op")
         auth_provider = SymmetricKeyAuthenticationProvider.parse(device_connection_string)
         pipeline = IoTHubPipeline(auth_provider)
-        op = pipeline._pipeline.run_op.call_args[0][0]
+        op = pipeline._pipeline.run_op.call_args[0][1]
         assert pipeline._pipeline.run_op.call_count == 1
         assert isinstance(op, pipeline_ops_iothub.SetAuthProviderOperation)
         assert op.auth_provider is auth_provider
@@ -131,24 +141,36 @@ class TestIoTHubPipelineInstantiation(object):
     @pytest.mark.it(
         "Propagates exceptions that occurred in execution upon unsuccessful completion of the SetAuthProviderOperation"
     )
-    def test_sas_auth_op_fail(self, mocker, device_connection_string):
-        mocker.patch.object(pipeline_stages_base, "PipelineRootStage")
-        auth_provider = SymmetricKeyAuthenticationProvider.parse(device_connection_string)
-        pipeline = IoTHubPipeline(auth_provider)
-        op = pipeline._pipeline.run_op.call_args[0][0]
-        op.error = Exception()
+    def test_sas_auth_op_fail(self, mocker, device_connection_string, fake_exception):
+        old_execute_op = pipeline_stages_base.PipelineRootStage._execute_op
 
-        with pytest.raises(Exception):
-            op.callback(op)
+        def fail_set_auth_provider(self, op):
+            if isinstance(op, pipeline_stages_base.SetAuthProviderOperation):
+                op.error = fake_exception
+                operation_flow.complete_op(stage=self, op=op)
+            else:
+                old_execute_op(self, op)
+
+        mocker.patch.object(
+            pipeline_stages_base.PipelineRootStage,
+            "_execute_op",
+            side_effect=fail_set_auth_provider,
+        )
+
+        auth_provider = SymmetricKeyAuthenticationProvider.parse(device_connection_string)
+        with pytest.raises(fake_exception.__class__):
+            IoTHubPipeline(auth_provider)
 
     @pytest.mark.it(
         "Runs a SetX509AuthProviderOperation with the provided AuthenticationProvider on the pipeline, if using SAS based authentication"
     )
     def test_cert_auth(self, mocker, x509):
-        mocker.patch.object(pipeline_stages_base, "PipelineRootStage")
-        auth_provider = X509AuthenticationProvider("somehostname", "somedevice", x509)
+        mocker.spy(pipeline_stages_base.PipelineRootStage, "run_op")
+        auth_provider = X509AuthenticationProvider(
+            hostname="somehostname", device_id="somedevice", x509=x509
+        )
         pipeline = IoTHubPipeline(auth_provider)
-        op = pipeline._pipeline.run_op.call_args[0][0]
+        op = pipeline._pipeline.run_op.call_args[0][1]
         assert pipeline._pipeline.run_op.call_count == 1
         assert isinstance(op, pipeline_ops_iothub.SetX509AuthProviderOperation)
         assert op.auth_provider is auth_provider
@@ -156,30 +178,41 @@ class TestIoTHubPipelineInstantiation(object):
     @pytest.mark.it(
         "Propagates exceptions that occurred in execution upon unsuccessful completion of the SetX509AuthProviderOperation"
     )
-    def test_cert_auth_op_fail(self, mocker, x509):
-        mocker.patch.object(pipeline_stages_base, "PipelineRootStage")
-        auth_provider = X509AuthenticationProvider("somehostname", "somedevice", x509)
-        pipeline = IoTHubPipeline(auth_provider)
-        op = pipeline._pipeline.run_op.call_args[0][0]
-        op.error = Exception()
+    def test_cert_auth_op_fail(self, mocker, x509, fake_exception):
+        old_execute_op = pipeline_stages_base.PipelineRootStage._execute_op
 
-        with pytest.raises(Exception):
-            op.callback(op)
+        def fail_set_auth_provider(self, op):
+            if isinstance(op, pipeline_stages_base.SetX509AuthProviderOperation):
+                op.error = fake_exception
+                operation_flow.complete_op(stage=self, op=op)
+            else:
+                old_execute_op(self, op)
+
+        mocker.patch.object(
+            pipeline_stages_base.PipelineRootStage,
+            "_execute_op",
+            side_effect=fail_set_auth_provider,
+        )
+
+        auth_provider = X509AuthenticationProvider(
+            hostname="somehostname", device_id="somedevice", x509=x509
+        )
+        with pytest.raises(fake_exception.__class__):
+            IoTHubPipeline(auth_provider)
 
 
 @pytest.mark.describe("IoTHubPipeline - .connect()")
 class TestIoTHubPipelineConnect(object):
     @pytest.mark.it("Runs a ConnectOperation on the pipeline")
-    def test_runs_op(self, pipeline):
-        pipeline.connect()
+    def test_runs_op(self, pipeline, mocker):
+        cb = mocker.MagicMock()
+        pipeline.connect(callback=cb)
         assert pipeline._pipeline.run_op.call_count == 1
         assert isinstance(
             pipeline._pipeline.run_op.call_args[0][0], pipeline_ops_base.ConnectOperation
         )
 
-    @pytest.mark.it(
-        "Triggers an optionally provided callback upon successful completion of the ConnectOperation"
-    )
+    @pytest.mark.it("Triggers the callback upon successful completion of the ConnectOperation")
     def test_op_success_with_callback(self, mocker, pipeline):
         cb = mocker.MagicMock()
 
@@ -192,54 +225,34 @@ class TestIoTHubPipelineConnect(object):
         op.callback(op)
 
         assert cb.call_count == 1
+        assert cb.call_args == mocker.call()
 
     @pytest.mark.it(
-        "Does nothing upon successful completion of the ConnectOperation if no callback is provided"
+        "Calls the callback with the error upon unsuccessful completion of the ConnectOperation"
     )
-    def test_op_success_no_callback(self, pipeline):
-        pipeline.connect()
-        op = pipeline._pipeline.run_op.call_args[0][0]
-        op.callback(op)
-
-        # No assertions required - if the code executes without error, the test passes
-
-    @pytest.mark.it("Raise SystemExit upon unsuccessful completion of the ConnectOperation")
     def test_op_fail(self, mocker, pipeline):
-        pipeline.connect()
-        op = pipeline._pipeline.run_op.call_args[0][0]
-        op.error = Exception()
-
-        with pytest.raises(SystemExit):
-            op.callback(op)
-
-    @pytest.mark.it(
-        "Does not trigger callback upon unsuccessful completion of the ConnectOperation"
-    )
-    def test_op_fail_no_callback(self, mocker, pipeline):
         cb = mocker.MagicMock()
+
         pipeline.connect(callback=cb)
         op = pipeline._pipeline.run_op.call_args[0][0]
         op.error = Exception()
 
-        with pytest.raises(SystemExit):
-            op.callback(op)
-
-        assert cb.call_count == 0
+        op.callback(op)
+        assert cb.call_count == 1
+        assert cb.call_args == mocker.call(error=op.error)
 
 
 @pytest.mark.describe("IoTHubPipeline - .disconnect()")
 class TestIoTHubPipelineDisconnect(object):
     @pytest.mark.it("Runs a DisconnectOperation on the pipeline")
-    def test_runs_op(self, pipeline):
-        pipeline.disconnect()
+    def test_runs_op(self, pipeline, mocker):
+        pipeline.disconnect(callback=mocker.MagicMock())
         assert pipeline._pipeline.run_op.call_count == 1
         assert isinstance(
             pipeline._pipeline.run_op.call_args[0][0], pipeline_ops_base.DisconnectOperation
         )
 
-    @pytest.mark.it(
-        "Triggers an optionally provided callback upon successful completion of the DisconnectOperation"
-    )
+    @pytest.mark.it("Triggers the callback upon successful completion of the DisconnectOperation")
     def test_op_success_with_callback(self, mocker, pipeline):
         cb = mocker.MagicMock()
 
@@ -252,46 +265,28 @@ class TestIoTHubPipelineDisconnect(object):
         op.callback(op)
 
         assert cb.call_count == 1
+        assert cb.call_args == mocker.call()
 
     @pytest.mark.it(
-        "Does nothing upon successful completion of the DisconnectOperation if no callback is provided"
+        "Calls the callback with the error upon unsuccessful completion of the DisconnectOperation"
     )
-    def test_op_success_no_callback(self, pipeline):
-        pipeline.disconnect()
-        op = pipeline._pipeline.run_op.call_args[0][0]
-        op.callback(op)
-
-        # No assertions required - if the code executes without error, the test passes
-
-    @pytest.mark.it("Raise SystemExit upon unsuccessful completion of the DisconnectOperation")
     def test_op_fail(self, mocker, pipeline):
-        pipeline.disconnect()
-        op = pipeline._pipeline.run_op.call_args[0][0]
-        op.error = Exception()
-
-        with pytest.raises(SystemExit):
-            op.callback(op)
-
-    @pytest.mark.it(
-        "Does not trigger callback upon unsuccessful completion of the DisconnectOperation"
-    )
-    def test_op_fail_no_callback(self, mocker, pipeline):
         cb = mocker.MagicMock()
         pipeline.disconnect(callback=cb)
+
         op = pipeline._pipeline.run_op.call_args[0][0]
         op.error = Exception()
+        op.callback(op)
 
-        with pytest.raises(SystemExit):
-            op.callback(op)
-
-        assert cb.call_count == 0
+        assert cb.call_count == 1
+        assert cb.call_args == mocker.call(error=op.error)
 
 
 @pytest.mark.describe("IoTHubPipeline - .send_message()")
 class TestIoTHubPipelineSendD2CMessage(object):
     @pytest.mark.it("Runs a SendD2CMessageOperation with the provided message on the pipeline")
-    def test_runs_op(self, pipeline, message):
-        pipeline.send_message(message)
+    def test_runs_op(self, pipeline, message, mocker):
+        pipeline.send_message(message, callback=mocker.MagicMock())
         op = pipeline._pipeline.run_op.call_args[0][0]
 
         assert pipeline._pipeline.run_op.call_count == 1
@@ -299,7 +294,7 @@ class TestIoTHubPipelineSendD2CMessage(object):
         assert op.message == message
 
     @pytest.mark.it(
-        "Triggers an optionally provided callback upon successful completion of the SendD2CMessageOperation"
+        "Triggers the callback upon successful completion of the SendD2CMessageOperation"
     )
     def test_op_success_with_callback(self, mocker, pipeline, message):
         cb = mocker.MagicMock()
@@ -313,39 +308,21 @@ class TestIoTHubPipelineSendD2CMessage(object):
         op.callback(op)
 
         assert cb.call_count == 1
+        assert cb.call_args == mocker.call()
 
     @pytest.mark.it(
-        "Does nothing upon successful completion of the SendD2CMessageOperation if no callback is provided"
+        "Calls the callback with the error upon unsuccessful completion of the SendD2CMessageOperation"
     )
-    def test_op_success_no_callback(self, pipeline, message):
-        pipeline.send_message(message)
-        op = pipeline._pipeline.run_op.call_args[0][0]
-        op.callback(op)
-
-        # No assertions required - if the code executes without error, the test passes
-
-    @pytest.mark.it("Raise SystemExit upon unsuccessful completion of the SendD2CMessageOperation")
     def test_op_fail(self, mocker, pipeline, message):
-        pipeline.send_message(message)
-        op = pipeline._pipeline.run_op.call_args[0][0]
-        op.error = Exception()
-
-        with pytest.raises(SystemExit):
-            op.callback(op)
-
-    @pytest.mark.it(
-        "Does not trigger callback upon unsuccessful completion of the SendD2CMessageOperation"
-    )
-    def test_op_fail_no_callback(self, mocker, pipeline, message):
         cb = mocker.MagicMock()
         pipeline.send_message(message, callback=cb)
+
         op = pipeline._pipeline.run_op.call_args[0][0]
         op.error = Exception()
+        op.callback(op)
 
-        with pytest.raises(SystemExit):
-            op.callback(op)
-
-        assert cb.call_count == 0
+        assert cb.call_count == 1
+        assert cb.call_args == mocker.call(error=op.error)
 
 
 @pytest.mark.describe("IoTHubPipeline - .send_output_event()")
@@ -357,8 +334,8 @@ class TestIoTHubPipelineSendOutputEvent(object):
         return message
 
     @pytest.mark.it("Runs a SendOutputEventOperation with the provided Message on the pipeline")
-    def test_runs_op(self, pipeline, message):
-        pipeline.send_output_event(message)
+    def test_runs_op(self, pipeline, message, mocker):
+        pipeline.send_output_event(message, callback=mocker.MagicMock())
         op = pipeline._pipeline.run_op.call_args[0][0]
 
         assert pipeline._pipeline.run_op.call_count == 1
@@ -366,7 +343,7 @@ class TestIoTHubPipelineSendOutputEvent(object):
         assert op.message == message
 
     @pytest.mark.it(
-        "Triggers an optionally provided callback upon successful completion of the SendOutputEventOperation"
+        "Triggers the callback upon successful completion of the SendOutputEventOperation"
     )
     def test_op_success_with_callback(self, mocker, pipeline, message):
         cb = mocker.MagicMock()
@@ -380,39 +357,21 @@ class TestIoTHubPipelineSendOutputEvent(object):
         op.callback(op)
 
         assert cb.call_count == 1
+        assert cb.call_args == mocker.call()
 
     @pytest.mark.it(
-        "Does nothing upon successful completion of the SendOutputEventOperation if no callback is provided"
+        "Calls the callback with the error upon unsuccessful completion of the SendOutputEventOperation"
     )
-    def test_op_success_no_callback(self, pipeline, message):
-        pipeline.send_output_event(message)
-        op = pipeline._pipeline.run_op.call_args[0][0]
-        op.callback(op)
-
-        # No assertions required - if the code executes without error, the test passes
-
-    @pytest.mark.it("Raise SystemExit upon unsuccessful completion of the SendOutputEventOperation")
     def test_op_fail(self, mocker, pipeline, message):
-        pipeline.send_output_event(message)
-        op = pipeline._pipeline.run_op.call_args[0][0]
-        op.error = Exception()
-
-        with pytest.raises(SystemExit):
-            op.callback(op)
-
-    @pytest.mark.it(
-        "Does not trigger callback upon unsuccessful completion of the SendOutputEventOperation"
-    )
-    def test_op_fail_no_callback(self, mocker, pipeline, message):
         cb = mocker.MagicMock()
         pipeline.send_output_event(message, callback=cb)
+
         op = pipeline._pipeline.run_op.call_args[0][0]
         op.error = Exception()
+        op.callback(op)
 
-        with pytest.raises(SystemExit):
-            op.callback(op)
-
-        assert cb.call_count == 0
+        assert cb.call_count == 1
+        assert cb.call_args == mocker.call(error=op.error)
 
 
 @pytest.mark.describe("IoTHubPipeline - .send_method_response()")
@@ -420,8 +379,8 @@ class TestIoTHubPipelineSendMethodResponse(object):
     @pytest.mark.it(
         "Runs a SendMethodResponseOperation with the provided MethodResponse on the pipeline"
     )
-    def test_runs_op(self, pipeline, method_response):
-        pipeline.send_method_response(method_response)
+    def test_runs_op(self, pipeline, method_response, mocker):
+        pipeline.send_method_response(method_response, callback=mocker.MagicMock())
         op = pipeline._pipeline.run_op.call_args[0][0]
 
         assert pipeline._pipeline.run_op.call_count == 1
@@ -429,7 +388,7 @@ class TestIoTHubPipelineSendMethodResponse(object):
         assert op.method_response == method_response
 
     @pytest.mark.it(
-        "Triggers an optionally provided callback upon successful completion of the SendMethodResponseOperation"
+        "Triggers the callback upon successful completion of the SendMethodResponseOperation"
     )
     def test_op_success_with_callback(self, mocker, pipeline, method_response):
         cb = mocker.MagicMock()
@@ -443,41 +402,21 @@ class TestIoTHubPipelineSendMethodResponse(object):
         op.callback(op)
 
         assert cb.call_count == 1
+        assert cb.call_args == mocker.call()
 
     @pytest.mark.it(
-        "Does nothing upon successful completion of the SendMethodResponseOperation if no callback is provided"
-    )
-    def test_op_success_no_callback(self, pipeline, method_response):
-        pipeline.send_method_response(method_response)
-        op = pipeline._pipeline.run_op.call_args[0][0]
-        op.callback(op)
-
-        # No assertions required - if the code executes without error, the test passes
-
-    @pytest.mark.it(
-        "Raise SystemExit upon unsuccessful completion of the SendMethodResponseOperation"
+        "Calls the callback with the error upon unsuccessful completion of the SendMethodResponseOperation"
     )
     def test_op_fail(self, mocker, pipeline, method_response):
-        pipeline.send_method_response(method_response)
-        op = pipeline._pipeline.run_op.call_args[0][0]
-        op.error = Exception()
-
-        with pytest.raises(SystemExit):
-            op.callback(op)
-
-    @pytest.mark.it(
-        "Does not trigger callback upon unsuccessful completion of the SendMethodResponseOperation"
-    )
-    def test_op_fail_no_callback(self, mocker, pipeline, method_response):
         cb = mocker.MagicMock()
         pipeline.send_method_response(method_response, callback=cb)
+
         op = pipeline._pipeline.run_op.call_args[0][0]
         op.error = Exception()
+        op.callback(op)
 
-        with pytest.raises(SystemExit):
-            op.callback(op)
-
-        assert cb.call_count == 0
+        assert cb.call_count == 1
+        assert cb.call_args == mocker.call(error=op.error)
 
 
 @pytest.mark.describe("IoTHubPipeline - .get_twin()")
@@ -506,30 +445,21 @@ class TestIoTHubPipelineGetTwin(object):
         op.callback(op)
 
         assert cb.call_count == 1
+        assert cb.call_args == mocker.call(twin=None)
 
-    @pytest.mark.it("Raise SystemExit upon unsuccessful completion of the GetTwinOperation")
+    @pytest.mark.it(
+        "Calls the callback with the error upon unsuccessful completion of the GetTwinOperation"
+    )
     def test_op_fail(self, mocker, pipeline):
         cb = mocker.MagicMock()
         pipeline.get_twin(callback=cb)
+
         op = pipeline._pipeline.run_op.call_args[0][0]
         op.error = Exception()
+        op.callback(op)
 
-        with pytest.raises(SystemExit):
-            op.callback(op)
-
-    @pytest.mark.it(
-        "Does not trigger callback upon unsuccessful completion of the GetTwinOperation"
-    )
-    def test_op_fail_no_callback(self, mocker, pipeline):
-        cb = mocker.MagicMock()
-        pipeline.get_twin(callback=cb)
-        op = pipeline._pipeline.run_op.call_args[0][0]
-        op.error = Exception()
-
-        with pytest.raises(SystemExit):
-            op.callback(op)
-
-        assert cb.call_count == 0
+        assert cb.call_count == 1
+        assert cb.call_args == mocker.call(twin=None, error=op.error)
 
 
 @pytest.mark.describe("IoTHubPipeline - .patch_twin_reported_properties()")
@@ -537,8 +467,8 @@ class TestIoTHubPipelinePatchTwinReportedProperties(object):
     @pytest.mark.it(
         "Runs a PatchTwinReportedPropertiesOperation with the provided twin patch on the pipeline"
     )
-    def test_runs_op(self, pipeline, twin_patch):
-        pipeline.patch_twin_reported_properties(twin_patch)
+    def test_runs_op(self, pipeline, twin_patch, mocker):
+        pipeline.patch_twin_reported_properties(twin_patch, callback=mocker.MagicMock())
         op = pipeline._pipeline.run_op.call_args[0][0]
 
         assert pipeline._pipeline.run_op.call_count == 1
@@ -546,7 +476,7 @@ class TestIoTHubPipelinePatchTwinReportedProperties(object):
         assert op.patch == twin_patch
 
     @pytest.mark.it(
-        "Triggers an optionally provided callback upon successful completion of the PatchTwinReportedPropertiesOperation"
+        "Triggers the callback upon successful completion of the PatchTwinReportedPropertiesOperation"
     )
     def test_op_success_with_callback(self, mocker, pipeline, twin_patch):
         cb = mocker.MagicMock()
@@ -560,66 +490,46 @@ class TestIoTHubPipelinePatchTwinReportedProperties(object):
         op.callback(op)
 
         assert cb.call_count == 1
+        assert cb.call_args == mocker.call()
 
     @pytest.mark.it(
-        "Does nothing upon successful completion of the PatchTwinReportedPropertiesOperation if no callback is provided"
-    )
-    def test_op_success_no_callback(self, pipeline, twin_patch):
-        pipeline.patch_twin_reported_properties(twin_patch)
-        op = pipeline._pipeline.run_op.call_args[0][0]
-        op.callback(op)
-
-        # No assertions required - if the code executes without error, the test passes
-
-    @pytest.mark.it(
-        "Raise SystemExit upon unsuccessful completion of the PatchTwinReportedPropertiesOperation"
+        "Calls the callback with the error upon unsuccessful completion of the PatchTwinReportedPropertiesOperation"
     )
     def test_op_fail(self, mocker, pipeline, twin_patch):
-        pipeline.patch_twin_reported_properties(twin_patch)
-        op = pipeline._pipeline.run_op.call_args[0][0]
-        op.error = Exception()
-
-        with pytest.raises(SystemExit):
-            op.callback(op)
-
-    @pytest.mark.it(
-        "Does not trigger callback upon unsuccessful completion of the PatchTwinReportedPropertiesOperation"
-    )
-    def test_op_fail_no_callback(self, mocker, pipeline, twin_patch):
         cb = mocker.MagicMock()
         pipeline.patch_twin_reported_properties(twin_patch, callback=cb)
+
         op = pipeline._pipeline.run_op.call_args[0][0]
         op.error = Exception()
+        op.callback(op)
 
-        with pytest.raises(SystemExit):
-            op.callback(op)
-
-        assert cb.call_count == 0
+        assert cb.call_count == 1
+        assert cb.call_args == mocker.call(error=op.error)
 
 
 @pytest.mark.describe("IoTHubPipeline - .enable_feature()")
 class TestIoTHubPipelineEnableFeature(object):
     @pytest.mark.it("Marks the feature as enabled")
     @pytest.mark.parametrize("feature", all_features)
-    def test_mark_feature_enabled(self, pipeline, feature):
+    def test_mark_feature_enabled(self, pipeline, feature, mocker):
         assert not pipeline.feature_enabled[feature]
-        pipeline.enable_feature(feature)
+        pipeline.enable_feature(feature, callback=mocker.MagicMock())
         assert pipeline.feature_enabled[feature]
 
     @pytest.mark.it("Raises ValueError if the feature_name is invalid")
-    def test_invalid_feature_name(self, pipeline):
+    def test_invalid_feature_name(self, pipeline, mocker):
         bad_feature = "not-a-feature-name"
         assert bad_feature not in pipeline.feature_enabled
         with pytest.raises(ValueError):
-            pipeline.enable_feature(bad_feature)
+            pipeline.enable_feature(bad_feature, callback=mocker.MagicMock())
         assert bad_feature not in pipeline.feature_enabled
 
     # TODO: what about features that are already disabled?
 
     @pytest.mark.it("Runs a EnableFeatureOperation with the provided feature_name on the pipeline")
     @pytest.mark.parametrize("feature", all_features)
-    def test_runs_op(self, pipeline, feature):
-        pipeline.enable_feature(feature)
+    def test_runs_op(self, pipeline, feature, mocker):
+        pipeline.enable_feature(feature, callback=mocker.MagicMock())
         op = pipeline._pipeline.run_op.call_args[0][0]
 
         assert pipeline._pipeline.run_op.call_count == 1
@@ -627,7 +537,7 @@ class TestIoTHubPipelineEnableFeature(object):
         assert op.feature_name == feature
 
     @pytest.mark.it(
-        "Triggers an optionally provided callback upon successful completion of the EnableFeatureOperation"
+        "Triggers the callback upon successful completion of the EnableFeatureOperation"
     )
     @pytest.mark.parametrize("feature", all_features)
     def test_op_success_with_callback(self, mocker, pipeline, feature):
@@ -642,69 +552,49 @@ class TestIoTHubPipelineEnableFeature(object):
         op.callback(op)
 
         assert cb.call_count == 1
+        assert cb.call_args == mocker.call()
 
     @pytest.mark.it(
-        "Does nothing upon successful completion of the EnableFeatureOperation if no callback is provided"
+        "Calls the callback with the error upon unsuccessful completion of the EnableFeatureOperation"
     )
-    @pytest.mark.parametrize("feature", all_features)
-    def test_op_success_no_callback(self, pipeline, feature):
-        pipeline.enable_feature(feature)
-        op = pipeline._pipeline.run_op.call_args[0][0]
-        op.callback(op)
-
-        # No assertions required - if the code executes without error, the test passes
-
-    @pytest.mark.it("Raise SystemExit upon unsuccessful completion of the EnableFeatureOperation")
     @pytest.mark.parametrize("feature", all_features)
     def test_op_fail(self, mocker, pipeline, feature):
-        pipeline.enable_feature(feature)
-        op = pipeline._pipeline.run_op.call_args[0][0]
-        op.error = Exception()
-
-        with pytest.raises(SystemExit):
-            op.callback(op)
-
-    @pytest.mark.it(
-        "Does not trigger callback upon unsuccessful completion of the EnableFeatureOperation"
-    )
-    @pytest.mark.parametrize("feature", all_features)
-    def test_op_fail_no_callback(self, mocker, pipeline, feature):
         cb = mocker.MagicMock()
         pipeline.enable_feature(feature, callback=cb)
+
         op = pipeline._pipeline.run_op.call_args[0][0]
         op.error = Exception()
+        op.callback(op)
 
-        with pytest.raises(SystemExit):
-            op.callback(op)
-
-        assert cb.call_count == 0
+        assert cb.call_count == 1
+        assert cb.call_args == mocker.call(error=op.error)
 
 
 @pytest.mark.describe("IoTHubPipeline - .disable_feature()")
 class TestIoTHubPipelineDisableFeature(object):
     @pytest.mark.it("Marks the feature as disabled")
     @pytest.mark.parametrize("feature", all_features)
-    def test_mark_feature_disabled(self, pipeline, feature):
+    def test_mark_feature_disabled(self, pipeline, feature, mocker):
         # enable feature first
         pipeline.feature_enabled[feature] = True
         assert pipeline.feature_enabled[feature]
-        pipeline.disable_feature(feature)
+        pipeline.disable_feature(feature, callback=mocker.MagicMock())
         assert not pipeline.feature_enabled[feature]
 
     @pytest.mark.it("Raises ValueError if the feature_name is invalid")
-    def test_invalid_feature_name(self, pipeline):
+    def test_invalid_feature_name(self, pipeline, mocker):
         bad_feature = "not-a-feature-name"
         assert bad_feature not in pipeline.feature_enabled
         with pytest.raises(ValueError):
-            pipeline.disable_feature(bad_feature)
+            pipeline.disable_feature(bad_feature, callback=mocker.MagicMock())
         assert bad_feature not in pipeline.feature_enabled
 
     # TODO: what about features that are already disabled?
 
     @pytest.mark.it("Runs a DisableFeatureOperation with the provided feature_name on the pipeline")
     @pytest.mark.parametrize("feature", all_features)
-    def test_runs_op(self, pipeline, feature):
-        pipeline.disable_feature(feature)
+    def test_runs_op(self, pipeline, feature, mocker):
+        pipeline.disable_feature(feature, callback=mocker.MagicMock())
         op = pipeline._pipeline.run_op.call_args[0][0]
 
         assert pipeline._pipeline.run_op.call_count == 1
@@ -712,7 +602,7 @@ class TestIoTHubPipelineDisableFeature(object):
         assert op.feature_name == feature
 
     @pytest.mark.it(
-        "Triggers an optionally provided callback upon successful completion of the DisableFeatureOperation"
+        "Triggers the callback upon successful completion of the DisableFeatureOperation"
     )
     @pytest.mark.parametrize("feature", all_features)
     def test_op_success_with_callback(self, mocker, pipeline, feature):
@@ -727,42 +617,22 @@ class TestIoTHubPipelineDisableFeature(object):
         op.callback(op)
 
         assert cb.call_count == 1
+        assert cb.call_args == mocker.call()
 
     @pytest.mark.it(
-        "Does nothing upon successful completion of the DisableFeatureOperation if no callback is provided"
+        "Calls the callback with the error upon unsuccessful completion of the DisableFeatureOperation"
     )
     @pytest.mark.parametrize("feature", all_features)
-    def test_op_success_no_callback(self, pipeline, feature):
-        pipeline.disable_feature(feature)
-        op = pipeline._pipeline.run_op.call_args[0][0]
-        op.callback(op)
-
-        # No assertions required - if the code executes without error, the test passes
-
-    @pytest.mark.it("Raise SystemExit upon unsuccessful completion of the DisableFeatureOperation")
-    @pytest.mark.parametrize("feature", all_features)
-    def test_op_fail(self, mocker, pipeline, feature):
-        pipeline.disable_feature(feature)
-        op = pipeline._pipeline.run_op.call_args[0][0]
-        op.error = Exception()
-
-        with pytest.raises(SystemExit):
-            op.callback(op)
-
-    @pytest.mark.it(
-        "Does not trigger callback upon unsuccessful completion of the DisableFeatureOperation"
-    )
-    @pytest.mark.parametrize("feature", all_features)
-    def test_op_fail_no_callback(self, mocker, pipeline, feature):
+    def _est_op_fail(self, mocker, pipeline, feature):
         cb = mocker.MagicMock()
         pipeline.disable_feature(feature, callback=cb)
+
         op = pipeline._pipeline.run_op.call_args[0][0]
         op.error = Exception()
+        op.callback(op)
 
-        with pytest.raises(SystemExit):
-            op.callback(op)
-
-        assert cb.call_count == 0
+        assert cb.call_count == 1
+        assert cb.call_args == mocker.call(error=op.error)
 
 
 @pytest.mark.describe("IoTHubPipeline - EVENT: Connected")

--- a/azure-iot-device/tests/provisioning/aio/test_async_provisioning_device_client.py
+++ b/azure-iot-device/tests/provisioning/aio/test_async_provisioning_device_client.py
@@ -50,6 +50,14 @@ def fake_x509():
     return X509(fake_x509_cert_file_value, fake_x509_cert_key_file, fake_pass_phrase)
 
 
+# automatically mock the transport for all tests in this file.
+@pytest.fixture(autouse=True)
+def mock_transport(mocker):
+    mocker.patch(
+        "azure.iot.device.common.pipeline.pipeline_stages_mqtt.MQTTTransport", autospec=True
+    )
+
+
 @pytest.mark.describe("ProvisioningDeviceClient - Init")
 class TestClientCreate(object):
     xfail_notimplemented = pytest.mark.xfail(raises=NotImplementedError, reason="Unimplemented")
@@ -65,14 +73,10 @@ class TestClientCreate(object):
         ],
     )
     async def test_create_from_symmetric_key(self, mocker, protocol):
-        patch_set_sym_client = mocker.patch.object(
-            pipeline_ops_provisioning, "SetSymmetricKeySecurityClientOperation"
-        )
         client = ProvisioningDeviceClient.create_from_symmetric_key(
             fake_provisioning_host, fake_symmetric_key, fake_registration_id, fake_id_scope
         )
         assert isinstance(client, ProvisioningDeviceClient)
-        assert patch_set_sym_client.call_count == 1
         assert client._provisioning_pipeline is not None
 
     @pytest.mark.it("Is created from a x509 certificate key and protocol")
@@ -86,27 +90,24 @@ class TestClientCreate(object):
         ],
     )
     async def test_create_from_x509_cert(self, mocker, protocol):
-        patch_set_x509_client = mocker.patch.object(
-            pipeline_ops_provisioning, "SetX509SecurityClientOperation"
-        )
         client = ProvisioningDeviceClient.create_from_x509_certificate(
             fake_provisioning_host, fake_registration_id, fake_id_scope, fake_x509()
         )
         assert isinstance(client, ProvisioningDeviceClient)
-        assert patch_set_x509_client.call_count == 1
         assert client._provisioning_pipeline is not None
 
 
 @pytest.mark.describe("ProvisioningDeviceClient")
 class TestClientCallsPollingMachine(object):
-
-    @pytest.mark.it("Register calls register on polling machine with passed in callback and returns the registration result")
+    @pytest.mark.it(
+        "Register calls register on polling machine with passed in callback and returns the registration result"
+    )
     async def test_client_register_success_calls_polling_machine_register_with_callback(
         self, mocker, mock_polling_machine
     ):
         # Override callback to pass successful result
         def register_complete_success_callback(callback):
-            callback(create_success_result())
+            callback(result=create_success_result())
 
         mocker.patch.object(
             mock_polling_machine, "register", side_effect=register_complete_success_callback
@@ -130,9 +131,11 @@ class TestClientCallsPollingMachine(object):
         assert result.registration_state.device_id == fake_device_id
         assert result.registration_state.assigned_hub == fake_assigned_hub
 
-    @pytest.mark.it("Register calls register on polling machine with passed in callback and returns no result when an error has occured")
+    @pytest.mark.it(
+        "Register calls register on polling machine with passed in callback and raises the error when an error has occured"
+    )
     async def test_client_register_failure_calls_polling_machine_register_with_callback(
-            self, mocker, mock_polling_machine
+        self, mocker, mock_polling_machine
     ):
         # Override callback to pass successful result
         def register_complete_failure_callback(callback):
@@ -149,11 +152,11 @@ class TestClientCallsPollingMachine(object):
         mock_polling_machine_init.return_value = mock_polling_machine
 
         client = ProvisioningDeviceClient(mqtt_provisioning_pipeline)
-        result = await client.register()
+        with pytest.raises(RuntimeError):
+            await client.register()
 
         assert mock_polling_machine.register.call_count == 1
         assert callable(mock_polling_machine.register.call_args[1]["callback"])
-        assert result is None
 
     @pytest.mark.it("Cancel calls cancel on polling machine with passed in callback")
     async def test_client_cancel_calls_polling_machine_cancel_with_callback(

--- a/azure-iot-device/tests/provisioning/internal/test_polling_machine.py
+++ b/azure-iot-device/tests/provisioning/internal/test_polling_machine.py
@@ -235,8 +235,8 @@ class TestRegisterResponse(object):
         assert state_based_mqtt.send_request.call_args_list[0][1]["request_payload"] == " "
 
         assert mock_callback.call_count == 1
-        assert isinstance(mock_callback.call_args[0][0], RegistrationResult)
-        registration_result = mock_callback.call_args[0][0]
+        assert isinstance(mock_callback.call_args[1]["result"], RegistrationResult)
+        registration_result = mock_callback.call_args[1]["result"]
 
         registration_result.request_id == fake_request_id
         registration_result.operation_id == fake_operation_id
@@ -283,8 +283,8 @@ class TestRegisterResponse(object):
         assert state_based_mqtt.send_request.call_args_list[0][1]["request_payload"] == " "
 
         assert mock_callback.call_count == 1
-        assert isinstance(mock_callback.call_args[0][1], ValueError)
-        assert mock_callback.call_args[0][1].args[0] == "Incoming message failure"
+        assert isinstance(mock_callback.call_args[1]["error"], ValueError)
+        assert mock_callback.call_args[1]["error"].args[0] == "Incoming message failure"
 
     @pytest.mark.it(
         "Calls callback of register with error when there is a response with unknown registration status"
@@ -327,9 +327,11 @@ class TestRegisterResponse(object):
         polling_machine._on_disconnect_completed_error()
 
         assert mock_callback.call_count == 1
-        assert isinstance(mock_callback.call_args[0][1], ValueError)
-        assert mock_callback.call_args[0][1].args[0] == "Other types of failure have occurred."
-        assert mock_callback.call_args[0][1].args[1] == fake_payload_result
+        assert isinstance(mock_callback.call_args[1]["error"], ValueError)
+        assert (
+            mock_callback.call_args[1]["error"].args[0] == "Other types of failure have occurred."
+        )
+        assert mock_callback.call_args[1]["error"].args[1] == fake_payload_result
 
     @pytest.mark.it("Calls register again when there is a response with status code > 429")
     def test_receive_register_response_greater_than_429_does_register_again(self, mocker):
@@ -413,7 +415,7 @@ class TestRegisterResponse(object):
         assert state_based_mqtt.send_request.call_count == 1
         assert state_based_mqtt.send_request.call_args_list[0][1]["request_id"] == fake_request_id
         assert mock_callback.call_count == 1
-        assert mock_callback.call_args[0][1].args[0] == "Time is up for query timer"
+        assert mock_callback.call_args[1]["error"].args[0] == "Time is up for query timer"
 
 
 @pytest.mark.describe("PollingMachine - Query Response")
@@ -607,7 +609,7 @@ class TestQueryResponse(object):
         assert state_based_mqtt.send_request.call_args_list[1][1]["request_payload"] == " "
 
         assert mock_callback.call_count == 1
-        assert isinstance(mock_callback.call_args[0][0], RegistrationResult)
+        assert isinstance(mock_callback.call_args[1]["result"], RegistrationResult)
 
     @pytest.mark.it(
         "Calls callback of register with error when there is a failed query response with status code > 300 & status code < 429"
@@ -683,8 +685,8 @@ class TestQueryResponse(object):
         assert state_based_mqtt.send_request.call_args_list[1][1]["request_payload"] == " "
 
         assert mock_callback.call_count == 1
-        assert isinstance(mock_callback.call_args[0][1], ValueError)
-        assert mock_callback.call_args[0][1].args[0] == "Incoming message failure"
+        assert isinstance(mock_callback.call_args[1]["error"], ValueError)
+        assert mock_callback.call_args[1]["error"].args[0] == "Incoming message failure"
 
     @pytest.mark.it("Calls query again when there is a response with status code > 429")
     def test_receive_query_response_greater_than_429_does_query_again_with_same_operation_id(

--- a/azure-iot-device/tests/provisioning/test_sync_provisioning_device_client.py
+++ b/azure-iot-device/tests/provisioning/test_sync_provisioning_device_client.py
@@ -46,6 +46,14 @@ def fake_x509():
     return X509(fake_x509_cert_file_value, fake_x509_cert_key_file, fake_pass_phrase)
 
 
+# automatically mock the transport for all tests in this file.
+@pytest.fixture(autouse=True)
+def mock_transport(mocker):
+    mocker.patch(
+        "azure.iot.device.common.pipeline.pipeline_stages_mqtt.MQTTTransport", autospec=True
+    )
+
+
 @pytest.mark.describe("ProvisioningDeviceClient - Init")
 class TestClientCreate(object):
     xfail_notimplemented = pytest.mark.xfail(raises=NotImplementedError, reason="Unimplemented")
@@ -61,15 +69,10 @@ class TestClientCreate(object):
         ],
     )
     def test_create_from_symmetric_key(self, mocker, protocol):
-        patch_set_sym_client = mocker.patch.object(
-            pipeline_ops_provisioning, "SetSymmetricKeySecurityClientOperation"
-        )
-        patch_set_sym_client.callback = mocker.MagicMock()
         client = ProvisioningDeviceClient.create_from_symmetric_key(
             fake_provisioning_host, fake_symmetric_key, fake_registration_id, fake_id_scope
         )
         assert isinstance(client, ProvisioningDeviceClient)
-        assert patch_set_sym_client.call_count == 1
         assert client._provisioning_pipeline is not None
 
     @pytest.mark.it("Is created from a x509 certificate key and protocol")
@@ -83,26 +86,24 @@ class TestClientCreate(object):
         ],
     )
     def test_create_from_x509_cert(self, mocker, protocol):
-        patch_set_x509_client = mocker.patch.object(
-            pipeline_ops_provisioning, "SetX509SecurityClientOperation"
-        )
         client = ProvisioningDeviceClient.create_from_x509_certificate(
             fake_provisioning_host, fake_registration_id, fake_id_scope, fake_x509()
         )
         assert isinstance(client, ProvisioningDeviceClient)
-        assert patch_set_x509_client.call_count == 1
         assert client._provisioning_pipeline is not None
 
 
 @pytest.mark.describe("ProvisioningDeviceClient")
 class TestClientRegister(object):
-    @pytest.mark.it("Register calls register on polling machine with passed in callback and returns the registration result")
+    @pytest.mark.it(
+        "Register calls register on polling machine with passed in callback and returns the registration result"
+    )
     def test_client_register_success_calls_polling_machine_register_with_callback(
         self, mocker, mock_polling_machine
     ):
         # Override callback to pass successful result
         def register_complete_success_callback(callback):
-            callback(create_success_result())
+            callback(result=create_success_result())
 
         mocker.patch.object(
             mock_polling_machine, "register", side_effect=register_complete_success_callback
@@ -126,9 +127,11 @@ class TestClientRegister(object):
         assert result.registration_state.device_id == fake_device_id
         assert result.registration_state.assigned_hub == fake_assigned_hub
 
-    @pytest.mark.it("Register calls register on polling machine with passed in callback and returns no result when an error has occured")
+    @pytest.mark.it(
+        "Register calls register on polling machine with passed in callback and raises the error when an error has occured"
+    )
     def test_client_register_failure_calls_polling_machine_register_with_callback(
-            self, mocker, mock_polling_machine
+        self, mocker, mock_polling_machine
     ):
         # Override callback to pass successful result
         def register_complete_failure_callback(callback):
@@ -145,11 +148,11 @@ class TestClientRegister(object):
         mock_polling_machine_init.return_value = mock_polling_machine
 
         client = ProvisioningDeviceClient(mqtt_provisioning_pipeline)
-        result = client.register()
+        with pytest.raises(RuntimeError):
+            client.register()
 
         assert mock_polling_machine.register.call_count == 1
         assert callable(mock_polling_machine.register.call_args[1]["callback"])
-        assert result is None
 
     @pytest.mark.it("Cancel calls cancel on polling machine with passed in callback")
     def test_client_cancel_calls_polling_machine_cancel_with_callback(

--- a/azure_provisioning_e2e/pytest.ini
+++ b/azure_provisioning_e2e/pytest.ini
@@ -1,2 +1,2 @@
 [pytest]
-addopts = --timeout 90
+addopts = --timeout 20

--- a/azure_provisioning_e2e/pytest.ini
+++ b/azure_provisioning_e2e/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+addopts = --timeout 90

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -3,6 +3,7 @@ pytest-mock
 pytest-asyncio; python_version >= '3.5'
 pytest-testdox>=1.1.1
 pytest-cov
+pytest-timeout
 mock #remove this as soon as no references to it remain in the code
 flake8
 azure-iothub-provisioningserviceclient >= 1.2.0  # Only needed for end to end tests for DPS


### PR DESCRIPTION
…API call

This is a big part of our error and retry strategy.  With this change, pipeline errors are raised from the user's API call in both sync and async cases.  

@cartertinney  - we had talked about some of the changes to `AsyncCallback` before. Hopefully this looks pleasing (or at least familiar).

Do do this, I needed to:
* changed iothub and provisioning clients to raise errors on pipeline failures.
* @olivakar - this includes a behavior change for provisioning -- now register will raise on pipeline errors, but not on serivce error.  Is this what we want?
* Get rid of the `def remove_this_code` callbacks in the pipeline initializers.  Pipeline initialier won't return until pipeline is initialized.
* Get rid of the raise SystemExit() failure code in favor of returning errors to the user thread.
* Change AsyncCallback to add errors to the completion object.  This way, the user sees pipeline errors raised from the Future as they expect.
* Change AsyncCallback to take an optional `return_arg_name` instead of a sync_callback.  All of our sync callbacks were almost identical anyway and this saves us from copy pasta.
* Add EventedCallback which behaves like AsyncCallback for the sync case.  E.g. it takes an optional `return_arg_name` and the wait() method raises pipeline errors just like AsyncCallback does.
* Change callback parameters in iothub_pipeline and provisioning_pipeline to be required.  Both of these objects are internal and there's no reason to make callback optional -- it just adds overhead and we always provide the callback anyway.  